### PR TITLE
[RSDK-8761] - Use ISO datetime format

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,18 +66,19 @@ The `From` and `To` timestamps are used to specify the start and end times for v
 
 #### Datetime Format
 
-The datetime format used is: `YYYY-MM-DD_HH-MM-SS`
+The datetime format used is ISO 8601: `YYYY-MM-DDTHH:MM:SS`
 
 - `YYYY`: Year (e.g., 2023)
 - `MM`: Month (e.g., 01 for January)
 - `DD`: Day (e.g., 15)
+- `T`: Literal character 'T' separating date and time
 - `HH`: Hour in 24-hour format (e.g., 14 for 2 PM)
 - `MM`: Minutes (e.g., 30)
 - `SS`: Seconds (e.g., 45)
 
 #### Datetime Example
 
-- `2024-01-15_14-30-45` represents January 15, 2024, at 2:30:45 PM.
+- `2024-01-15T14:30:45` represents January 15, 2024, at 2:30:45 PM.
 
 ### `save`
 

--- a/cam/segmenter.go
+++ b/cam/segmenter.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	outputPattern = "%Y-%m-%d_%H-%M-%S.mp4"
+	outputPattern = "%Y-%m-%dT%H:%M:%SZ.mp4"
 )
 
 type segmenter struct {

--- a/cam/segmenter.go
+++ b/cam/segmenter.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	outputPattern = "%Y-%m-%dT%H:%M:%SZ.mp4"
+	outputPattern = "%Y-%m-%dT%H:%M:%S.mp4"
 )
 
 type segmenter struct {

--- a/cam/utils.go
+++ b/cam/utils.go
@@ -22,11 +22,13 @@ import (
 type codecType int
 
 const (
-	// CodecUnknown represents an unknown codec type.
+	// datetimePattern for ISO 8601 format.
+	dateTimePattern = "2006-01-02T15:04:05"
+	// codecUnknown represents an unknown codec type.
 	codecUnknown codecType = iota
-	// CodecH264 represents the H.264 codec type.
+	// codecH264 represents the H.264 codec type.
 	codecH264
-	// CodecH265 represents the H.265 codec type.
+	// codecH265 represents the H.265 codec type.
 	codecH265
 )
 
@@ -189,12 +191,22 @@ func getSortedFiles(path string) ([]string, error) {
 func extractDateTimeFromFilename(filePath string) (time.Time, error) {
 	baseName := filepath.Base(filePath)
 	dateTimeStr := strings.TrimSuffix(baseName, filepath.Ext(baseName))
-	return time.Parse(time.RFC3339, dateTimeStr)
+	return time.Parse(dateTimePattern, dateTimeStr)
 }
 
 // formatDateTimeToString formats the date and time to a string in RFC3339 format.
 func formatDateTimeToString(dateTime time.Time) string {
-	return dateTime.Format(time.RFC3339)
+	return dateTime.Format(dateTimePattern)
+}
+
+// parseDateTimeString parses a date and time string in the format "2006-01-02_15-04-05".
+// Returns a time.Time object and an error if the string is not in the correct format.
+func parseDateTimeString(datetime string) (time.Time, error) {
+	dateTime, err := time.Parse(dateTimePattern, datetime)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return dateTime, nil
 }
 
 // matchStorageToRange returns a list of files that fall within the provided time range.
@@ -233,7 +245,6 @@ func matchStorageToRange(files []string, start, end time.Time, duration time.Dur
 			}
 		}
 	}
-
 	return matchedFiles
 }
 
@@ -265,7 +276,7 @@ func validateSaveCommand(command map[string]interface{}) (time.Time, time.Time, 
 	if !ok {
 		return time.Time{}, time.Time{}, "", false, errors.New("from timestamp not found")
 	}
-	from, err := time.Parse(time.RFC3339, fromStr)
+	from, err := parseDateTimeString(fromStr)
 	if err != nil {
 		return time.Time{}, time.Time{}, "", false, err
 	}
@@ -273,7 +284,7 @@ func validateSaveCommand(command map[string]interface{}) (time.Time, time.Time, 
 	if !ok {
 		return time.Time{}, time.Time{}, "", false, errors.New("to timestamp not found")
 	}
-	to, err := time.Parse(time.RFC3339, toStr)
+	to, err := parseDateTimeString(toStr)
 	if err != nil {
 		return time.Time{}, time.Time{}, "", false, err
 	}
@@ -297,7 +308,7 @@ func validateFetchCommand(command map[string]interface{}) (time.Time, time.Time,
 	if !ok {
 		return time.Time{}, time.Time{}, errors.New("from timestamp not found")
 	}
-	from, err := time.Parse(time.RFC3339, fromStr)
+	from, err := parseDateTimeString(fromStr)
 	if err != nil {
 		return time.Time{}, time.Time{}, err
 	}
@@ -305,7 +316,7 @@ func validateFetchCommand(command map[string]interface{}) (time.Time, time.Time,
 	if !ok {
 		return time.Time{}, time.Time{}, errors.New("to timestamp not found")
 	}
-	to, err := time.Parse(time.RFC3339, toStr)
+	to, err := parseDateTimeString(toStr)
 	if err != nil {
 		return time.Time{}, time.Time{}, err
 	}

--- a/cam/utils.go
+++ b/cam/utils.go
@@ -188,28 +188,13 @@ func getSortedFiles(path string) ([]string, error) {
 // extractDateTimeFromFilename extracts the date and time from the filename.
 func extractDateTimeFromFilename(filePath string) (time.Time, error) {
 	baseName := filepath.Base(filePath)
-	parts := strings.Split(baseName, "_")
-	if len(parts) < 2 {
-		return time.Time{}, fmt.Errorf("invalid file name: %s", baseName)
-	}
-	datePart := parts[0]
-	timePart := strings.TrimSuffix(parts[1], filepath.Ext(parts[1]))
-	dateTimeStr := datePart + "_" + timePart
-	return parseDateTimeString(dateTimeStr)
+	dateTimeStr := strings.TrimSuffix(baseName, filepath.Ext(baseName))
+	return time.Parse(time.RFC3339, dateTimeStr)
 }
 
-// parseDateTimeString parses a date and time string in the format "2006-01-02_15-04-05".
-// Returns a time.Time object and an error if the string is not in the correct format.
-func parseDateTimeString(datetime string) (time.Time, error) {
-	dateTime, err := time.Parse("2006-01-02_15-04-05", datetime)
-	if err != nil {
-		return time.Time{}, err
-	}
-	return dateTime, nil
-}
-
+// formatDateTimeToString formats the date and time to a string in RFC3339 format.
 func formatDateTimeToString(dateTime time.Time) string {
-	return dateTime.Format("2006-01-02_15-04-05")
+	return dateTime.Format(time.RFC3339)
 }
 
 // matchStorageToRange returns a list of files that fall within the provided time range.
@@ -280,7 +265,7 @@ func validateSaveCommand(command map[string]interface{}) (time.Time, time.Time, 
 	if !ok {
 		return time.Time{}, time.Time{}, "", false, errors.New("from timestamp not found")
 	}
-	from, err := parseDateTimeString(fromStr)
+	from, err := time.Parse(time.RFC3339, fromStr)
 	if err != nil {
 		return time.Time{}, time.Time{}, "", false, err
 	}
@@ -288,7 +273,7 @@ func validateSaveCommand(command map[string]interface{}) (time.Time, time.Time, 
 	if !ok {
 		return time.Time{}, time.Time{}, "", false, errors.New("to timestamp not found")
 	}
-	to, err := parseDateTimeString(toStr)
+	to, err := time.Parse(time.RFC3339, toStr)
 	if err != nil {
 		return time.Time{}, time.Time{}, "", false, err
 	}
@@ -312,7 +297,7 @@ func validateFetchCommand(command map[string]interface{}) (time.Time, time.Time,
 	if !ok {
 		return time.Time{}, time.Time{}, errors.New("from timestamp not found")
 	}
-	from, err := parseDateTimeString(fromStr)
+	from, err := time.Parse(time.RFC3339, fromStr)
 	if err != nil {
 		return time.Time{}, time.Time{}, err
 	}
@@ -320,7 +305,7 @@ func validateFetchCommand(command map[string]interface{}) (time.Time, time.Time,
 	if !ok {
 		return time.Time{}, time.Time{}, errors.New("to timestamp not found")
 	}
-	to, err := parseDateTimeString(toStr)
+	to, err := time.Parse(time.RFC3339, toStr)
 	if err != nil {
 		return time.Time{}, time.Time{}, err
 	}


### PR DESCRIPTION
## Description

Currently, I am using a non standard datetime format `YYYY-MM-DD_HH-MM-SS` which I adopted from FFmpeg segment examples.

To make the DoCommand endpoint easier to use, this PR moves to standard `ISO 8601` format `YYYY-MM-DDTHH:MM:SS`.

### golang:
- golang does not support standard `ISO 8601`, rather, it uses `RFC 3339` which includes the timezone.
  - It is not possible for the `strftime` formatter in FFmpeg to match this.

### python:


## Testing
- storage ✅ 
- save ✅ 
- fetch ✅ 