### PR TITLE
[RSDK-8756] - Make YUV422 parser fast

### DIFF
--- a/cam/encoder.go
+++ b/cam/encoder.go
@@ -186,14 +186,12 @@ func imageToYUV422(img image.Image) ([]byte, error) {
 
 	for y := 0; y < height; y++ {
 		ySrcStart := ycbcrImg.YOffset(rect.Min.X, rect.Min.Y+y)
-		yDstStart := y * width
-		copy(rawYUV[yDstStart:yDstStart+width], ycbcrImg.Y[ySrcStart:ySrcStart+width])
-	}
-
-	for y := 0; y < height; y++ {
 		cSrcStart := ycbcrImg.COffset(rect.Min.X, rect.Min.Y+y)
+		yDstStart := y * width
 		uDstStart := y * halfWidth
 		vDstStart := y * halfWidth
+
+		copy(rawYUV[yDstStart:yDstStart+width], ycbcrImg.Y[ySrcStart:ySrcStart+width])
 		copy(rawYUV[ySize+uDstStart:ySize+uDstStart+halfWidth], ycbcrImg.Cb[cSrcStart:cSrcStart+halfWidth])
 		copy(rawYUV[ySize+uSize+vDstStart:ySize+uSize+vDstStart+halfWidth], ycbcrImg.Cr[cSrcStart:cSrcStart+halfWidth])
 	}


### PR DESCRIPTION
## Description

Moves from pixel by pixel fill to a row-wise copy to unpad yuv422 bytes.

## Benchmark

prev: `2.23487ms`
new:  `622.487µs`

~3.5X faster