### PR TITLE
[RSDK-8794] - Add AMD64 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,15 @@ on:
 
 jobs:
   tests:
-    runs-on: buildjet-8vcpu-ubuntu-2204-arm
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runs-on: ubuntu-latest
+          - platform: linux/arm64
+            runs-on: buildjet-8vcpu-ubuntu-2204-arm
+
+    runs-on: ${{ matrix.runs-on }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ lint: tool-install $(FFMPEG_BUILD)
 
 test: $(BIN_OUTPUT_PATH)/video-store
 	git lfs pull
+	cp $(BIN_OUTPUT_PATH)/video-store bin/video-store
 	go test -v ./tests/
 
 module: $(BIN_OUTPUT_PATH)/video-store

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ FFMPEG_OPTS ?= --prefix=$(FFMPEG_BUILD) \
                --enable-protocol=crypto \
                --enable-bsf=h264_mp4toannexb
 
-CGO_LDFLAGS := "-L$(FFMPEG_BUILD)/lib -lavcodec -lavutil -lavformat -l:libjpeg.a /usr/lib/aarch64-linux-gnu/libx264.a -lz"
+CGO_LDFLAGS := "-L$(FFMPEG_BUILD)/lib -lavcodec -lavutil -lavformat -l:libjpeg.a -l:libx264.a -lz"
 CGO_CFLAGS := -I$(FFMPEG_BUILD)/include
 GOFLAGS := -buildvcs=false
 export PKG_CONFIG_PATH=$(FFMPEG_BUILD)/lib/pkgconfig

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ test: $(BIN_OUTPUT_PATH)/video-store
 	git lfs pull
 	cp $(BIN_OUTPUT_PATH)/video-store bin/video-store
 	go test -v ./tests/
+	rm bin/video-store
 
 module: $(BIN_OUTPUT_PATH)/video-store
 	cp $(BIN_OUTPUT_PATH)/video-store bin/video-store

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	moduleBinPath           = "bin/linux-arm64/video-store"
+	moduleBinPath           = "bin/video-store"
 	videoStoreComponentName = "video-store-1"
 	testStoragePath         = "/tmp/video-storage"
 	testUploadPath          = "/tmp/video-upload"


### PR DESCRIPTION
## Description

Simple PR to officially support AMD64 builds.
- Remove hardcoded libx264.a path.
- Adds AMD64 to test  ci matrix.
- Small update to binary path for tests.

## Test
- Build/test working in local canon container ✅ 
- Test CI successful ✅ 