### PR TITLE
[RSDK-8848] - Test improvements bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,14 @@ lint: tool-install $(FFMPEG_BUILD)
 	CGO_CFLAGS=$(CGO_CFLAGS) GOFLAGS=$(GOFLAGS) $(TOOL_BIN)/golangci-lint run -v --fix --config=./etc/.golangci.yaml
 
 test: $(BIN_OUTPUT_PATH)/video-store
+ifeq ($(shell which ffmpeg > /dev/null 2>&1; echo $$?), 1)
+ifeq ($(SOURCE_OS),linux)
+	sudo apt update && sudo apt install -y ffmpeg
+endif
+ifeq ($(SOURCE_OS),darwin)
+	brew update && brew install ffmpeg
+endif
+endif
 	git lfs pull
 	cp $(BIN_OUTPUT_PATH)/video-store bin/video-store
 	go test -v ./tests/

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -69,6 +69,14 @@ func cleanVideoStoreDir() error {
 	return cmd.Run()
 }
 
+func testVideoPlayback(t *testing.T, videoPath string) {
+	_, err := os.Stat(videoPath)
+	test.That(t, err, test.ShouldBeNil)
+	cmd := exec.Command("ffmpeg", "-v", "error", "-i", videoPath, "-f", "null", "-")
+	err = cmd.Run()
+	test.That(t, err, test.ShouldBeNil)
+}
+
 func TestModuleConfiguration(t *testing.T) {
 	fullModuleBinPath, err := getModuleBinPath()
 	if err != nil {

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -27,6 +28,7 @@ const (
 )
 
 func setupViamServer(ctx context.Context, configStr string) (robot.Robot, error) {
+	cleanVideoStoreDir()
 	logger := logging.NewLogger("video-store-module")
 	cfg, err := config.FromReader(ctx, "default.json", bytes.NewReader([]byte(configStr)), logger)
 	if err != nil {
@@ -48,6 +50,23 @@ func getModuleBinPath() (string, error) {
 	}
 	fullModuleBinPath := filepath.Join(currentDir, "..", moduleBinPath)
 	return fullModuleBinPath, nil
+}
+
+func cleanVideoStoreDir() error {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	videoStoreDir := filepath.Join(currentDir, "video-storage")
+	err = os.Chdir(videoStoreDir)
+	if err != nil {
+		return err
+	}
+	defer os.Chdir(currentDir) // Ensure we change back to the original directory
+	cmd := exec.Command("git", "clean", "-fdx")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 func TestModuleConfiguration(t *testing.T) {
@@ -75,8 +94,8 @@ func TestModuleConfiguration(t *testing.T) {
 						"storage_path": "%s"
 					},
 					"cam_props": {
-						"width": 1920,
-						"height": 1080,
+						"width": 1280,
+						"height": 720,
 						"framerate": 30
 					},
 					"video": {
@@ -181,8 +200,8 @@ func TestModuleConfiguration(t *testing.T) {
 					"camera": "fake-cam-1",
 					"sync": "data_manager-1",
 					"cam_props": {
-						"width": 1920,
-						"height": 1080,
+						"width": 1280,
+						"height": 720,
 						"framerate": 30
 					},
 					"video": {
@@ -247,8 +266,8 @@ func TestModuleConfiguration(t *testing.T) {
 						"storage_path": "/tmp/video-storage"
 					},
 					"cam_props": {
-						"width": 1920,
-						"height": 1080,
+						"width": 1280,
+						"height": 720,
 						"framerate": 30
 					},
 					"video": {
@@ -375,8 +394,8 @@ func TestModuleConfiguration(t *testing.T) {
 						"storage_path": "/tmp"
 					},
 					"cam_props": {
-						"width": 1920,
-						"height": 1080,
+						"width": 1280,
+						"height": 720,
 						"framerate": 30
 					},
 					"video": {

--- a/tests/fetch_test.go
+++ b/tests/fetch_test.go
@@ -40,8 +40,8 @@ func TestFetchDoCommand(t *testing.T) {
 						"storage_path": "%s"
 					},
 					"cam_props": {
-						"width": 1920,
-						"height": 1080,
+						"width": 1280,
+						"height": 720,
 						"framerate": 30
 					},
 					"video": {

--- a/tests/fetch_test.go
+++ b/tests/fetch_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"go.viam.com/rdk/components/camera"
+	"go.viam.com/test"
 )
 
 func TestFetchDoCommand(t *testing.T) {
@@ -119,78 +120,50 @@ func TestFetchDoCommand(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 		r, err := setupViamServer(timeoutCtx, config1)
-		if err != nil {
-			t.Fatalf("failed to setup viam server: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		defer r.Close(timeoutCtx)
 		vs, err := camera.FromRobot(r, videoStoreComponentName)
-		if err != nil {
-			t.Fatalf("failed to get video store component: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		res, err := vs.DoCommand(timeoutCtx, fetchCmd1)
-		if err != nil {
-			t.Fatalf("failed to execute fetch command: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		video, ok := res["video"].(string)
-		if !ok {
-			t.Fatalf("failed to parse video from response: %v", res)
-		}
-		if video == "" {
-			t.Fatalf("video not found in response: %v", res)
-		}
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, video, test.ShouldNotBeEmpty)
 	})
 
 	t.Run("Test Fetch DoCommand Valid Time Range Over GRPC Limit.", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 		r, err := setupViamServer(timeoutCtx, config1)
-		if err != nil {
-			t.Fatalf("failed to setup viam server: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		defer r.Close(timeoutCtx)
 		vs, err := camera.FromRobot(r, videoStoreComponentName)
-		if err != nil {
-			t.Fatalf("failed to get video store component: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		_, err = vs.DoCommand(timeoutCtx, fetchCmd2)
-		if err == nil {
-			t.Fatalf("expected error but got nil")
-		}
+		test.That(t, err, test.ShouldNotBeNil)
 	})
 
 	t.Run("Test Fetch DoCommand Invalid Time Range.", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 		r, err := setupViamServer(timeoutCtx, config1)
-		if err != nil {
-			t.Fatalf("failed to setup viam server: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		defer r.Close(timeoutCtx)
 		vs, err := camera.FromRobot(r, videoStoreComponentName)
-		if err != nil {
-			t.Fatalf("failed to get video store component: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		_, err = vs.DoCommand(timeoutCtx, fetchCmd3)
-		if err == nil {
-			t.Fatalf("expected error for invalid time range")
-		}
+		test.That(t, err, test.ShouldNotBeNil)
 	})
 
 	t.Run("Test Fetch DoCommand Invalid Datetime Format.", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 		r, err := setupViamServer(timeoutCtx, config1)
-		if err != nil {
-			t.Fatalf("failed to setup viam server: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		defer r.Close(timeoutCtx)
 		vs, err := camera.FromRobot(r, videoStoreComponentName)
-		if err != nil {
-			t.Fatalf("failed to get video store component: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		_, err = vs.DoCommand(timeoutCtx, fetchCmd4)
-		if err == nil {
-			t.Fatalf("expected error for invalid datetime format")
-		}
+		test.That(t, err, test.ShouldNotBeNil)
 	})
 }

--- a/tests/fetch_test.go
+++ b/tests/fetch_test.go
@@ -141,6 +141,7 @@ func TestFetchDoCommand(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		_, err = vs.DoCommand(timeoutCtx, fetchCmd2)
 		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "grpc")
 	})
 
 	t.Run("Test Fetch DoCommand Invalid Time Range.", func(t *testing.T) {
@@ -153,6 +154,7 @@ func TestFetchDoCommand(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		_, err = vs.DoCommand(timeoutCtx, fetchCmd3)
 		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "range")
 	})
 
 	t.Run("Test Fetch DoCommand Invalid Datetime Format.", func(t *testing.T) {
@@ -165,5 +167,6 @@ func TestFetchDoCommand(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		_, err = vs.DoCommand(timeoutCtx, fetchCmd4)
 		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "parsing time")
 	})
 }

--- a/tests/save_test.go
+++ b/tests/save_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
 	"go.viam.com/rdk/components/camera"
+	"go.viam.com/test"
 )
 
 func TestSaveDoCommand(t *testing.T) {
@@ -126,110 +126,70 @@ func TestSaveDoCommand(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 		r, err := setupViamServer(timeoutCtx, config1)
-		if err != nil {
-			t.Fatalf("failed to setup viam server: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		defer r.Close(timeoutCtx)
 		vs, err := camera.FromRobot(r, videoStoreComponentName)
-		if err != nil {
-			t.Fatalf("failed to get video store component: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		res, err := vs.DoCommand(timeoutCtx, saveCmd1)
-		if err != nil {
-			t.Fatalf("failed to execute save command: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		filename, ok := res["filename"].(string)
-		if !ok {
-			t.Fatalf("failed to parse filename from response: %v", res)
-		}
-		if !strings.Contains(filename, "test-metadata") {
-			t.Fatalf("metadata not found in filename: %v", filename)
-		}
-		if !strings.Contains(filename, "2024-09-06_15-00-33") {
-			t.Fatalf("from timestamp not found in filename: %v", filename)
-		}
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, filename, test.ShouldContainSubstring, "test-metadata")
+		test.That(t, filename, test.ShouldContainSubstring, "2024-09-06_15-00-33")
 	})
 
 	t.Run("Test Save DoCommand Invalid Range", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 		r, err := setupViamServer(timeoutCtx, config1)
-		if err != nil {
-			t.Fatalf("failed to setup viam server: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		defer r.Close(timeoutCtx)
 		vs, err := camera.FromRobot(r, videoStoreComponentName)
-		if err != nil {
-			t.Fatalf("failed to get video store component: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		_, err = vs.DoCommand(timeoutCtx, saveCmd2)
-		if err == nil {
-			t.Fatalf("expected error for invalid time range")
-		}
+		test.That(t, err, test.ShouldNotBeNil)
 	})
 
 	t.Run("Test Save DoCommand Invalid Datetime Format", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 		r, err := setupViamServer(timeoutCtx, config1)
-		if err != nil {
-			t.Fatalf("failed to setup viam server: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		defer r.Close(timeoutCtx)
 		vs, err := camera.FromRobot(r, videoStoreComponentName)
-		if err != nil {
-			t.Fatalf("failed to get video store component: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		_, err = vs.DoCommand(timeoutCtx, saveCmd3)
-		if err == nil {
-			t.Fatalf("expected error for invalid datetime format")
-		}
+		test.That(t, err, test.ShouldNotBeNil)
 	})
 
 	t.Run("Test Save DoCommand Async", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 		r, err := setupViamServer(timeoutCtx, config1)
-		if err != nil {
-			t.Fatalf("failed to setup viam server: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		defer r.Close(timeoutCtx)
 		vs, err := camera.FromRobot(r, videoStoreComponentName)
-		if err != nil {
-			t.Fatalf("failed to get video store component: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		res, err := vs.DoCommand(timeoutCtx, saveCmd4)
-		if err != nil {
-			t.Fatalf("failed to execute save command: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		_, ok := res["filename"].(string)
-		if !ok {
-			t.Fatalf("failed to parse filename from response: %v", res)
-		}
+		test.That(t, ok, test.ShouldBeTrue)
 	})
 
 	t.Run("Test leftover concat txt files are cleaned up", func(t *testing.T) {
 		leftoverConcatTxtPath := filepath.Join("/tmp", "concat_test1.txt")
 		file, err := os.Create(leftoverConcatTxtPath)
-		if err != nil {
-			t.Fatalf("failed to create file: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		file.Close()
-		if _, err := os.Stat(leftoverConcatTxtPath); os.IsNotExist(err) {
-			t.Fatalf("file does not exist: %v", err)
-		}
+		_, err = os.Stat(leftoverConcatTxtPath)
+		test.That(t, os.IsNotExist(err), test.ShouldBeFalse)
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 		r, err := setupViamServer(timeoutCtx, config1)
-		if err != nil {
-			t.Fatalf("failed to setup viam server: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
 		_, err = camera.FromRobot(r, videoStoreComponentName)
-		if err != nil {
-			t.Fatalf("failed to get video store component: %v", err)
-		}
-		if _, err := os.Stat(leftoverConcatTxtPath); !os.IsNotExist(err) {
-			t.Fatalf("file still exists: %v", err)
-		}
+		test.That(t, err, test.ShouldBeNil)
+		_, err = os.Stat(leftoverConcatTxtPath)
+		test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
 	})
 }

--- a/tests/save_test.go
+++ b/tests/save_test.go
@@ -148,6 +148,7 @@ func TestSaveDoCommand(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		_, err = vs.DoCommand(timeoutCtx, saveCmd2)
 		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "range")
 	})
 
 	t.Run("Test Save DoCommand Invalid Datetime Format", func(t *testing.T) {
@@ -160,6 +161,7 @@ func TestSaveDoCommand(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		_, err = vs.DoCommand(timeoutCtx, saveCmd3)
 		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "parsing time")
 	})
 
 	t.Run("Test Save DoCommand Async", func(t *testing.T) {

--- a/tests/save_test.go
+++ b/tests/save_test.go
@@ -136,6 +136,8 @@ func TestSaveDoCommand(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 		test.That(t, filename, test.ShouldContainSubstring, "test-metadata")
 		test.That(t, filename, test.ShouldContainSubstring, "2024-09-06_15-00-33")
+		filePath := filepath.Join(testUploadPath, filename)
+		testVideoPlayback(t, filePath)
 	})
 
 	t.Run("Test Save DoCommand Invalid Range", func(t *testing.T) {
@@ -228,5 +230,6 @@ func TestSaveDoCommand(t *testing.T) {
 		concatPath := filepath.Join(testUploadPath, filename)
 		_, err = os.Stat(concatPath)
 		test.That(t, err, test.ShouldBeNil)
+		testVideoPlayback(t, concatPath)
 	})
 }

--- a/tests/save_test.go
+++ b/tests/save_test.go
@@ -202,14 +202,13 @@ func TestSaveDoCommand(t *testing.T) {
 		defer r.Close(timeoutCtx)
 		vs, err := camera.FromRobot(r, videoStoreComponentName)
 		test.That(t, err, test.ShouldBeNil)
-		// Wait for the video segment to be created.
+		// Wait for the first video segment to be created.
 		time.Sleep(10 * time.Second)
 		now := time.Now()
 		fromTime := now.Add(-5 * time.Second)
 		toTime := now
 		fromTimeStr := fromTime.Format("2006-01-02_15-04-05")
 		toTimeStr := toTime.Format("2006-01-02_15-04-05")
-		fmt.Printf("from: %s, to: %s\n", fromTimeStr, toTimeStr)
 		saveCmdNow := map[string]interface{}{
 			"command":  "save",
 			"from":     fromTimeStr,


### PR DESCRIPTION
## Description

- Moved from using `t.Fatal` to viam test package.
- Fixed segfault issue related to encoding with fake cam dependency.
- Added a cleanup utility to delete temporary storage files between viam-server runs.
- Added real-time async save test case.
- Added checks to to error message strings.
- Added checks to make sure that video clips are playable.

> I did not add in struct template loops as it did not make sense for config tests since template varies across tests.