### PR TITLE
[RSDK-8903] - Implement simple keyframe force interval

### DIFF
--- a/cam/cam.go
+++ b/cam/cam.go
@@ -31,7 +31,7 @@ const (
 	defaultVideoFormat    = "mp4"
 	defaultUploadPath     = ".viam/capture/video-upload"
 	defaultStoragePath    = ".viam/video-storage"
-	defaultLogLevel       = "info"
+	defaultLogLevel       = "error"
 
 	maxGRPCSize     = 1024 * 1024 * 32 // bytes
 	deleterInterval = 10               // minutes

--- a/cam/encoder.go
+++ b/cam/encoder.go
@@ -60,8 +60,11 @@ func newEncoder(
 	enc.codecCtx.max_b_frames = 0
 	presetCStr := C.CString(preset)
 	tuneCStr := C.CString("zerolatency")
+	forceKeyFramesExpr := fmt.Sprintf("expr:gte(t,n_forced*%d)", framerate)
+	forceKeyFramesCStr := C.CString(forceKeyFramesExpr)
 	defer C.free(unsafe.Pointer(presetCStr))
 	defer C.free(unsafe.Pointer(tuneCStr))
+	defer C.free(unsafe.Pointer(forceKeyFramesCStr))
 
 	// The user can set the preset and tune for the encoder. This affects the
 	// encoding speed and quality. See https://trac.ffmpeg.org/wiki/Encode/H.264
@@ -73,6 +76,10 @@ func newEncoder(
 		return nil, fmt.Errorf("av_dict_set failed: %s", ffmpegError(ret))
 	}
 	ret = C.av_dict_set(&opts, C.CString("tune"), tuneCStr, 0)
+	if ret < 0 {
+		return nil, fmt.Errorf("av_dict_set failed: %s", ffmpegError(ret))
+	}
+	ret = C.av_dict_set(&opts, C.CString("force_key_frames"), forceKeyFramesCStr, 0)
 	if ret < 0 {
 		return nil, fmt.Errorf("av_dict_set failed: %s", ffmpegError(ret))
 	}

--- a/examples/save_client.go
+++ b/examples/save_client.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"context"
+	"math/rand"
 	"os"
 	"time"
 
@@ -17,7 +18,6 @@ import (
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/robot/client"
 	"go.viam.com/utils/rpc"
-	"golang.org/x/exp/rand"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	go.viam.com/rdk v0.40.0
 	go.viam.com/test v1.1.1-0.20220913152726-5da9916c08a2
 	go.viam.com/utils v0.1.98
+	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
 	golang.org/x/mobile v0.0.0-20240112133503-c713f31d574b
 	golang.org/x/tools v0.22.0
 	gotest.tools/gotestsum v1.10.0
@@ -306,7 +307,6 @@ require (
 	go.viam.com/api v0.1.336 // indirect
 	goji.io v2.0.2+incompatible // indirect
 	golang.org/x/crypto v0.24.0 // indirect
-	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc // indirect
 	golang.org/x/exp/typeparams v0.0.0-20230224173230-c95f2b4c22f2 // indirect
 	golang.org/x/image v0.19.0 // indirect
 	golang.org/x/mod v0.18.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	go.viam.com/rdk v0.40.0
 	go.viam.com/test v1.1.1-0.20220913152726-5da9916c08a2
 	go.viam.com/utils v0.1.98
-	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
 	golang.org/x/mobile v0.0.0-20240112133503-c713f31d574b
 	golang.org/x/tools v0.22.0
 	gotest.tools/gotestsum v1.10.0
@@ -307,6 +306,7 @@ require (
 	go.viam.com/api v0.1.336 // indirect
 	goji.io v2.0.2+incompatible // indirect
 	golang.org/x/crypto v0.24.0 // indirect
+	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc // indirect
 	golang.org/x/exp/typeparams v0.0.0-20230224173230-c95f2b4c22f2 // indirect
 	golang.org/x/image v0.19.0 // indirect
 	golang.org/x/mod v0.18.0 // indirect


### PR DESCRIPTION
## Description

There was an issue where the segmenter would flake out after some time. This was due to a keyframe not being correctly inserted into the beginning of the segment as expected. It turns out, the `gop_size` encoder settings are more of a recommendation than an absolutely firm keyframe interval. Dependenging on scene changes, a keyframe could be inserted earlier than expected throwing off the synchronization between the encoder and segmenter.

FFmpeg codec options actually include a `force_key_frames` expression handler, so we do not even have to hand roll the key frame forces in our image loop! Basically a one line opt call to fix this : )

## Test
- Long running test with `viamrtsp` camera of size 960x480 and 20FPS
  - ~5 hours, ~3000 segments 
  - All playable so far...

https://github.com/user-attachments/assets/e18f8536-995b-4daf-bf58-d447f56ae407

`ffprobe -v error -select_streams v:0 -show_frames -print_format json 2024-10-03_17-48-40.mp4 > frames_info.json`
[frames_info.json](https://github.com/user-attachments/files/17250519/frames_info.json)

Update here after overnight test: ✅ 
- 10 GB storage,  8000 segments, 12 hours runtime