### PR TITLE
RSDK-8853: Replace fatal with test.That in do_command tests

### DIFF
--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -79,9 +79,7 @@ func testVideoPlayback(t *testing.T, videoPath string) {
 
 func TestModuleConfiguration(t *testing.T) {
 	fullModuleBinPath, err := getModuleBinPath()
-	if err != nil {
-		t.Fatalf("Failed to get module binary path: %v", err)
-	}
+	test.That(t, err, test.ShouldBeNil)
 
 	// Full configuration
 	config1 := fmt.Sprintf(`

--- a/tests/fetch_test.go
+++ b/tests/fetch_test.go
@@ -14,13 +14,9 @@ import (
 func TestFetchDoCommand(t *testing.T) {
 	storageRelativePath := "./video-storage"
 	storagePath, err := filepath.Abs(storageRelativePath)
-	if err != nil {
-		t.Fatalf("Failed to get absolute path: %v", err)
-	}
+	test.That(t, err, test.ShouldBeNil)
 	fullModuleBinPath, err := getModuleBinPath()
-	if err != nil {
-		t.Fatalf("Failed to get module bin path: %v", err)
-	}
+	test.That(t, err, test.ShouldBeNil)
 
 	config1 := fmt.Sprintf(`
 	{

--- a/tests/save_test.go
+++ b/tests/save_test.go
@@ -15,13 +15,9 @@ import (
 func TestSaveDoCommand(t *testing.T) {
 	storageRelativePath := "./video-storage"
 	storagePath, err := filepath.Abs(storageRelativePath)
-	if err != nil {
-		t.Fatalf("Failed to get absolute path: %v", err)
-	}
+	test.That(t, err, test.ShouldBeNil)
 	fullModuleBinPath, err := getModuleBinPath()
-	if err != nil {
-		t.Fatalf("Failed to get module bin path: %v", err)
-	}
+	test.That(t, err, test.ShouldBeNil)
 
 	config1 := fmt.Sprintf(`
 	{


### PR DESCRIPTION
Replaced `t.Fatalf()` with `test.That()` to match the format of the rest of the tests