### PR TITLE
[RSDK-9538] - Throttle frame fetches by configured framerate

### DIFF
--- a/cam/cam.go
+++ b/cam/cam.go
@@ -333,9 +333,8 @@ func (vs *videostore) Properties(_ context.Context) (camera.Properties, error) {
 	return camera.Properties{}, nil
 }
 
-// fetchFrames reads frames from the camera and stores the decoded image
-// in the latestFrame atomic pointer. This routine runs as fast as possible
-// to keep the latest frame up to date.
+// fetchFrames reads frames from the camera at the framerate interval
+// and stores the decoded image in the latestFrame atomic pointer.
 func (vs *videostore) fetchFrames(ctx context.Context) {
 	frameInterval := time.Second / time.Duration(vs.conf.Properties.Framerate)
 	ticker := time.NewTicker(frameInterval)


### PR DESCRIPTION
## Description

This PR simply adds a ticker throttle based on the specified framerate to the `fetchFrames` routine to prevent over-polling of the source camera. See ticket [here](https://viam.atlassian.net/browse/RSDK-9538) for analysis.

## Tests
- Verify that fetchFrames is now throttled to framerate ✅ 
```
-16T16:39:17.463Z"}
2024-12-16T16:39:18.454Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 19.18      {"log_ts":"2024-12-16T16:39:18.451Z"}
2024-12-16T16:39:19.463Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 19.03      {"log_ts":"2024-12-16T16:39:19.461Z"}
2024-12-16T16:39:20.416Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 18.97      {"log_ts":"2024-12-16T16:39:20.411Z"}
2024-12-16T16:39:21.362Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 19.00      {"log_ts":"2024-12-16T16:39:21.360Z"}
2024-12-16T16:39:22.359Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 19.08      {"log_ts":"2024-12-16T16:39:22.357Z"}
2024-12-16T16:39:23.351Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 19.23      {"log_ts":"2024-12-16T16:39:23.349Z"}
2024-12-16T16:39:24.348Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 19.28      {"log_ts":"2024-12-16T16:39:24.346Z"}
2024-12-16T16:39:25.315Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 18.94      {"log_ts":"2024-12-16T16:39:25.312Z"}
2024-12-16T16:39:26.302Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 19.21      {"log_ts":"2024-12-16T16:39:26.300Z"}
2024-12-16T16:39:27.300Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 19.24      {"log_ts":"2024-12-16T16:39:27.298Z"}
2024-12-16T16:39:28.298Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 19.26      {"log_ts":"2024-12-16T16:39:28.297Z"}
2024-12-16T16:39:29.313Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 19.04      {"log_ts":"2024-12-16T16:39:29.310Z"}
2024-12-16T16:39:30.308Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 19.09      {"log_ts":"2024-12-16T16:39:30.306Z"}
2024-12-16T16:39:31.312Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 19.05      {"log_ts":"2024-12-16T16:39:31.309Z"}
2024-12-16T16:39:32.272Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 18.80      {"log_ts":"2024-12-16T16:39:32.270Z"}
2024-12-16T16:39:33.257Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 19.30      {"log_ts":"2024-12-16T16:39:33.256Z"}
2024-12-16T16:39:34.249Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 19.26      {"log_ts":"2024-12-16T16:39:34.247Z"}
2024-12-16T16:39:35.247Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 19.29      {"log_ts":"2024-12-16T16:39:35.246Z"}
2024-12-16T16:39:36.242Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 19.39      {"log_ts":"2024-12-16T16:39:36.241Z"}
2024-12-16T16:39:37.258Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 19.11      {"log_ts":"2024-12-16T16:39:37.256Z"}
2024-12-16T16:39:38.261Z        INFO    rdk:component:camera/video-store        cam/cam.go:376  Current FPS: 19.05      {"log_ts":"2024-12
```
- Verify decreased CPU utilization with smaller `240p` frame size stream ✅ 

```
ffmpeg -re -f lavfi -i testsrc=size=360x240:rate=30 -vcodec libx264 -pix_fmt yuv420p -f rtsp -rtsp_transport tcp rtsp://0.0.0.0:8554/live.stream
```
<img width="1040" alt="Screenshot 2024-12-16 at 11 56 56 AM" src="https://github.com/user-attachments/assets/b6c39e3c-681f-4199-835a-4c0047952e32" />

<img width="1156" alt="Screenshot 2024-12-16 at 11 54 34 AM" src="https://github.com/user-attachments/assets/9309b851-f32b-4285-9bf2-013a30a87790" />
