### PR TITLE
[RSDK-9653, RSDK-9673] - Make resilient to unknown and changing frame sizes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ FFMPEG_OPTS ?= --prefix=$(FFMPEG_BUILD) \
 
 CGO_LDFLAGS := -L$(FFMPEG_BUILD)/lib -lavcodec -lavutil -lavformat -lz
 ifeq ($(SOURCE_OS),linux)
-	CGO_LDFLAGS += -l:libjpeg.a -l:libx264.a
+	CGO_LDFLAGS += -l:libx264.a
 endif
 ifeq ($(SOURCE_OS),darwin)
 	CGO_LDFLAGS += $(HOMEBREW_PREFIX)/Cellar/x264/r3108/lib/libx264.a -liconv

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ Additionally, make sure to add your configured data manager service to the `depe
 |                 | `upload_path`     | string  | optional  | Custom path to use for uploading files. If not under `~/.viam/capture`, you will need to add to `additional_sync_paths` in datamanager service configuration. |
 | `video`         |                   | object  | optional  |                                                                                                   |
 |                 | `format`          | string  | optional  | Name of video format to use (e.g., mp4).                                                          |
-|                 | `codec`           | string  | optional  | Name of video codec to use (e.g., h264).                                                         |
+|                 | `codec`           | string  | optional  | Name of video codec to use (e.g., h264).                                                          |
 |                 | `bitrate`         | integer | optional  | Throughput of encoder in bits per second. Higher for better quality video, and lower for better storage efficiency. |
 |                 | `preset`          | string  | optional  | Name of codec video preset to use. See [here](https://trac.ffmpeg.org/wiki/Encode/H.264#a2.Chooseapresetandtune) for preset options.                                                                |
-| `framerate`     |                   | integer | optional  | Frame rate of the video. Default value is 20 if not set.                                          |
+| `framerate`     |                   | integer | optional  | Frame rate of the video in frames per second. Default value is 20 if not set.                      |
 
 ### Example Configuration
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,6 @@ On the new component panel, copy and paste the following attribute template into
   "storage": {
     "segment_seconds": <int>,
     "size_gb": <int>,
-  },
-  "cam_props": {
-    "width": <int>,
-    "height": <int>,
-    "framerate": <int>
   }
 }
 ```
@@ -73,10 +68,7 @@ Additionally, make sure to add your configured data manager service to the `depe
 |                 | `codec`           | string  | optional  | Name of video codec to use (e.g., h264).                                                         |
 |                 | `bitrate`         | integer | optional  | Throughput of encoder in bits per second. Higher for better quality video, and lower for better storage efficiency. |
 |                 | `preset`          | string  | optional  | Name of codec video preset to use. See [here](https://trac.ffmpeg.org/wiki/Encode/H.264#a2.Chooseapresetandtune) for preset options.                                                                |
-| `cam_props`     |                   | object  | optional  |                                                                                                   |
-|                 | `width`           | integer | optional  | Width of the source camera frames in pixels. If unspecified, will try to autodetect by fetching a frame from the source camera.                                                    |
-|                 | `height`          | integer | optional  | Height of the source camera frames in pixels. If unspecified, will try to autodetect by fetching a frame from the source camera.                                                     |
-|                 | `framerate`       | integer | optional  | Number of frames per second provided by the source camera. Default is 20.                                                                            |
+| `framerate`     |                   | integer | optional  | Frame rate of the video. Default value is 20 if not set.                                          |
 
 ### Example Configuration
 
@@ -92,11 +84,6 @@ Additionally, make sure to add your configured data manager service to the `depe
     "storage": {
       "segment_seconds": 10,
       "size_gb": 50,
-    },
-    "cam_props": {
-      "width": 640,
-      "height": 480,
-      "framerate": 25
     }
   },
   "depends_on": [

--- a/cam/cam.go
+++ b/cam/cam.go
@@ -158,7 +158,7 @@ func newvideostore(
 	if newConf.Video.Format != "" {
 		format = newConf.Video.Format
 	}
-	if newConf.Framerate != 0 {
+	if newConf.Framerate > 0 {
 		vs.framerate = newConf.Framerate
 	}
 

--- a/cam/cam.go
+++ b/cam/cam.go
@@ -143,8 +143,7 @@ func newvideostore(
 	ffmppegLogLevel(logLevel)
 
 	// Create encoder to handle encoding of frames.
-	// TODO(seanp): Forcing h264 for now until h265 is supported.
-	codec := defaultVideoCodec
+	// TODO(seanp): Ignoring codec and using h264 for now until h265 is supported.
 	bitrate := defaultVideoBitrate
 	preset := defaultVideoPreset
 	format := defaultVideoFormat
@@ -164,7 +163,6 @@ func newvideostore(
 
 	vs.enc, err = newEncoder(
 		logger,
-		codec,
 		bitrate,
 		preset,
 		vs.framerate,

--- a/cam/cam.go
+++ b/cam/cam.go
@@ -116,7 +116,7 @@ func init() {
 }
 
 func newvideostore(
-	ctx context.Context,
+	_ context.Context,
 	deps resource.Dependencies,
 	conf resource.Config,
 	logger logging.Logger,

--- a/cam/cam.go
+++ b/cam/cam.go
@@ -102,6 +102,9 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 	if cfg.Sync == "" {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "sync")
 	}
+	if cfg.Framerate < 0 {
+		return nil, fmt.Errorf("invalid framerate %d, must be greater than 0", cfg.Framerate)
+	}
 
 	return []string{cfg.Camera}, nil
 }

--- a/cam/cam.go
+++ b/cam/cam.go
@@ -160,7 +160,7 @@ func newvideostore(
 	if newConf.Video.Format != "" {
 		format = newConf.Video.Format
 	}
-	if newConf.Framerate > 0 {
+	if newConf.Framerate != 0 {
 		vs.framerate = newConf.Framerate
 	}
 

--- a/cam/cam.go
+++ b/cam/cam.go
@@ -79,12 +79,6 @@ type video struct {
 	Format  string `json:"format,omitempty"`
 }
 
-// type cameraProperties struct {
-// 	Width     int `json:"width"`
-// 	Height    int `json:"height"`
-// 	Framerate int `json:"framerate"`
-// }
-
 // Config is the configuration for the video storage camera component.
 type Config struct {
 	Camera    string  `json:"camera"`
@@ -92,9 +86,6 @@ type Config struct {
 	Storage   storage `json:"storage"`
 	Video     video   `json:"video,omitempty"`
 	Framerate int     `json:"framerate,omitempty"`
-
-	// // TODO(seanp): Remove once camera properties are returned from camera component.
-	// Properties cameraProperties `json:"cam_props"`
 }
 
 // Validate validates the configuration for the video storage camera component.
@@ -171,31 +162,6 @@ func newvideostore(
 		vs.framerate = newConf.Framerate
 	}
 
-	// if newConf.Properties.Width == 0 && newConf.Properties.Height == 0 {
-	// 	vs.logger.Info("received unspecified frame width and height, fetching frame to get dimensions")
-	// 	for range make([]struct{}, numFetchFrameAttempts) {
-	// 		frame, err := camera.DecodeImageFromCamera(ctx, rutils.MimeTypeJPEG, nil, vs.cam)
-	// 		if err != nil {
-	// 			vs.logger.Warn("failed to get and decode frame from camera, retrying. Error: ", err)
-	// 			time.Sleep(retryInterval * time.Second)
-	// 			continue
-	// 		}
-	// 		bounds := frame.Bounds()
-	// 		newConf.Properties.Width = bounds.Dx()
-	// 		newConf.Properties.Height = bounds.Dy()
-	// 		vs.logger.Infof("received frame width and height: %d, %d", newConf.Properties.Width, newConf.Properties.Height)
-	// 		break
-	// 	}
-	// }
-	// if newConf.Properties.Width == 0 && newConf.Properties.Height == 0 {
-	// 	return nil, fmt.Errorf("failed to get source camera width and height after %d attempts", numFetchFrameAttempts)
-	// }
-
-	// if newConf.Properties.Framerate == 0 {
-	// 	newConf.Properties.Framerate = defaultFramerate
-	// }
-
-	vs.logger.Info("about to create encoder")
 	vs.enc, err = newEncoder(
 		logger,
 		codec,
@@ -243,7 +209,6 @@ func newvideostore(
 	}
 
 	vs.storagePath = storagePath
-	vs.logger.Info("about to create segmenter")
 	vs.seg, err = newSegmenter(
 		logger,
 		sizeGB,
@@ -252,7 +217,6 @@ func newvideostore(
 		format,
 	)
 	if err != nil {
-		vs.logger.Info("failed to create segmenter !!!")
 		return nil, err
 	}
 
@@ -262,7 +226,6 @@ func newvideostore(
 	if err != nil {
 		return nil, err
 	}
-	vs.logger.Info("about to create concater")
 	vs.conc, err = newConcater(
 		logger,
 		vs.storagePath,

--- a/cam/cam.go
+++ b/cam/cam.go
@@ -376,7 +376,7 @@ func (vs *videostore) processFrames(ctx context.Context) {
 				return
 			}
 			if reinit {
-				vs.logger.Info("reinitializing segmenter due to encoder reinit")
+				vs.logger.Info("reinitializing segmenter due to encoder refresh")
 				err = vs.seg.initialize(vs.enc.codecCtx)
 				if err != nil {
 					vs.logger.Error("failed to reinitialize segmenter", err)

--- a/cam/cam.go
+++ b/cam/cam.go
@@ -376,7 +376,7 @@ func (vs *videostore) processFrames(ctx context.Context) {
 				return
 			}
 			if reinit {
-				vs.logger.Info("reinitializing segmenter")
+				vs.logger.Info("reinitializing segmenter due to encoder reinit")
 				err = vs.seg.initialize(vs.enc.codecCtx)
 				if err != nil {
 					vs.logger.Error("failed to reinitialize segmenter", err)

--- a/cam/cam.go
+++ b/cam/cam.go
@@ -368,12 +368,12 @@ func (vs *videostore) processFrames(ctx context.Context) {
 				vs.logger.Debug("latest frame is not available yet")
 				continue
 			}
-			encoded, pts, dts, reinit, err := vs.enc.encode(*latestFrame)
+			encoded, pts, dts, frameDimsChanged, err := vs.enc.encode(*latestFrame)
 			if err != nil {
 				vs.logger.Error("failed to encode frame", err)
 				return
 			}
-			if reinit {
+			if frameDimsChanged {
 				vs.logger.Info("reinitializing segmenter due to encoder refresh")
 				err = vs.seg.initialize(vs.enc.codecCtx)
 				if err != nil {

--- a/cam/cam.go
+++ b/cam/cam.go
@@ -368,12 +368,12 @@ func (vs *videostore) processFrames(ctx context.Context) {
 				vs.logger.Debug("latest frame is not available yet")
 				continue
 			}
-			encoded, pts, dts, frameDimsChanged, err := vs.enc.encode(*latestFrame)
+			result, err := vs.enc.encode(*latestFrame)
 			if err != nil {
 				vs.logger.Error("failed to encode frame", err)
 				return
 			}
-			if frameDimsChanged {
+			if result.frameDimsChanged {
 				vs.logger.Info("reinitializing segmenter due to encoder refresh")
 				err = vs.seg.initialize(vs.enc.codecCtx)
 				if err != nil {
@@ -381,7 +381,7 @@ func (vs *videostore) processFrames(ctx context.Context) {
 					return
 				}
 			}
-			err = vs.seg.writeEncodedFrame(encoded, pts, dts)
+			err = vs.seg.writeEncodedFrame(result.encodedData, result.pts, result.dts)
 			if err != nil {
 				vs.logger.Error("failed to segment frame", err)
 				return

--- a/cam/cam.go
+++ b/cam/cam.go
@@ -370,14 +370,14 @@ func (vs *videostore) processFrames(ctx context.Context) {
 			}
 			result, err := vs.enc.encode(*latestFrame)
 			if err != nil {
-				vs.logger.Error("failed to encode frame", err)
+				vs.logger.Debug("failed to encode frame", err)
 				continue
 			}
 			if result.frameDimsChanged {
 				vs.logger.Info("reinitializing segmenter due to encoder refresh")
 				err = vs.seg.initialize(vs.enc.codecCtx)
 				if err != nil {
-					vs.logger.Error("failed to reinitialize segmenter", err)
+					vs.logger.Debug("failed to reinitialize segmenter", err)
 					// Hack that flags the encoder to reinitialize if segmenter fails to
 					// ensure that encoder and segmenter inits are in sync.
 					vs.enc.codecCtx = nil
@@ -386,7 +386,7 @@ func (vs *videostore) processFrames(ctx context.Context) {
 			}
 			err = vs.seg.writeEncodedFrame(result.encodedData, result.pts, result.dts)
 			if err != nil {
-				vs.logger.Error("failed to segment frame", err)
+				vs.logger.Debug("failed to segment frame", err)
 				continue
 			}
 		}

--- a/cam/encoder.go
+++ b/cam/encoder.go
@@ -64,6 +64,9 @@ func (e *encoder) initialize(width, height int) error {
 	if e.codecCtx != nil {
 		C.avcodec_close(e.codecCtx)
 		C.avcodec_free_context(&e.codecCtx)
+		// We need to reset the frame count when we reinitialize the encoder
+		// in order to ensure that keyframes are generated correctly.
+		e.frameCount = 0
 	}
 	if e.srcFrame != nil {
 		C.av_frame_free(&e.srcFrame)

--- a/cam/encoder.go
+++ b/cam/encoder.go
@@ -143,7 +143,12 @@ func (e *encoder) initialize(width, height int) (err error) {
 // If the polling loop is not running at the source framerate, the
 // PTS will lag behind actual run time.
 func (e *encoder) encode(frame image.Image) (encodeResult, error) {
-	var result encodeResult
+	result := encodeResult{
+		encodedData:      nil,
+		pts:              0,
+		dts:              0,
+		frameDimsChanged: false,
+	}
 	dy, dx := frame.Bounds().Dy(), frame.Bounds().Dx()
 	if e.codecCtx == nil || dy != int(e.codecCtx.height) || dx != int(e.codecCtx.width) {
 		e.logger.Infof("Initializing encoder with frame dimensions %dx%d", dx, dy)

--- a/cam/encoder.go
+++ b/cam/encoder.go
@@ -32,12 +32,10 @@ type encoder struct {
 	height     int
 	bitrate    int
 	preset     string
-	videoCodec codecType
 }
 
 func newEncoder(
 	logger logging.Logger,
-	videoCodec codecType,
 	bitrate int,
 	preset string,
 	framerate int,
@@ -55,7 +53,6 @@ func newEncoder(
 		height:     0,
 		frameCount: 0,
 		preset:     preset,
-		videoCodec: videoCodec,
 	}
 
 	return enc, nil
@@ -72,8 +69,7 @@ func (e *encoder) initialize(width, height int) error {
 	if e.srcFrame != nil {
 		C.av_frame_free(&e.srcFrame)
 	}
-	// codecID := lookupCodecIDByType(codecH264)
-	codecID := lookupCodecIDByType(e.videoCodec)
+	codecID := lookupCodecIDByType(codecH264)
 	codec := C.avcodec_find_encoder(codecID)
 	if codec == nil {
 		return errors.New("codec not found")

--- a/cam/encoder.go
+++ b/cam/encoder.go
@@ -32,6 +32,7 @@ type encoder struct {
 	height     int
 	bitrate    int
 	preset     string
+	videoCodec codecType
 }
 
 func newEncoder(
@@ -53,6 +54,7 @@ func newEncoder(
 		height:     0,
 		frameCount: 0,
 		preset:     preset,
+		videoCodec: videoCodec,
 	}
 
 	return enc, nil
@@ -66,7 +68,8 @@ func (e *encoder) initialize(width, height int) error {
 	if e.srcFrame != nil {
 		C.av_frame_free(&e.srcFrame)
 	}
-	codecID := lookupCodecIDByType(codecH264)
+	// codecID := lookupCodecIDByType(codecH264)
+	codecID := lookupCodecIDByType(e.videoCodec)
 	codec := C.avcodec_find_encoder(codecID)
 	if codec == nil {
 		return errors.New("codec not found")

--- a/cam/encoder.go
+++ b/cam/encoder.go
@@ -43,7 +43,8 @@ func newEncoder(
 	framerate int,
 ) (*encoder, error) {
 	// Initialize without codec context and source frame. We will spin up
-	// the codec context and source frame when we get the first frame.
+	// the codec context and source frame when we get the first frame or when
+	// a resize is needed.
 	enc := &encoder{
 		logger:     logger,
 		codecCtx:   nil,
@@ -64,8 +65,8 @@ func (e *encoder) initialize(width, height int) error {
 	if e.codecCtx != nil {
 		C.avcodec_close(e.codecCtx)
 		C.avcodec_free_context(&e.codecCtx)
-		// We need to reset the frame count when we reinitialize the encoder
-		// in order to ensure that keyframes are generated correctly.
+		// We need to reset the frame count when reinitializing the encoder
+		// in order to ensure that keyframes intervals are generated correctly.
 		e.frameCount = 0
 	}
 	if e.srcFrame != nil {

--- a/cam/encoder.go
+++ b/cam/encoder.go
@@ -143,9 +143,9 @@ func (e *encoder) encode(frame image.Image) ([]byte, int64, int64, bool, error) 
 		return nil, 0, 0, reinit, err
 	}
 
-	ySize := frame.Bounds().Dx() * frame.Bounds().Dy()
-	uSize := (frame.Bounds().Dx() / subsampleFactor) * frame.Bounds().Dy()
-	vSize := (frame.Bounds().Dx() / subsampleFactor) * frame.Bounds().Dy()
+	ySize := dx * dy
+	uSize := (dx / subsampleFactor) * dy
+	vSize := (dx / subsampleFactor) * dy
 	yPlane := C.CBytes(yuv[:ySize])
 	uPlane := C.CBytes(yuv[ySize : ySize+uSize])
 	vPlane := C.CBytes(yuv[ySize+uSize : ySize+uSize+vSize])
@@ -155,9 +155,9 @@ func (e *encoder) encode(frame image.Image) ([]byte, int64, int64, bool, error) 
 	e.srcFrame.data[0] = (*C.uint8_t)(yPlane)
 	e.srcFrame.data[1] = (*C.uint8_t)(uPlane)
 	e.srcFrame.data[2] = (*C.uint8_t)(vPlane)
-	e.srcFrame.linesize[0] = C.int(frame.Bounds().Dx())
-	e.srcFrame.linesize[1] = C.int(frame.Bounds().Dx() / subsampleFactor)
-	e.srcFrame.linesize[2] = C.int(frame.Bounds().Dx() / subsampleFactor)
+	e.srcFrame.linesize[0] = C.int(dx)
+	e.srcFrame.linesize[1] = C.int(dx / subsampleFactor)
+	e.srcFrame.linesize[2] = C.int(dx / subsampleFactor)
 
 	// Both PTS and DTS times are equal frameCount multiplied by the time_base.
 	// This assumes that the processFrame routine is running at the source framerate.

--- a/cam/encoder.go
+++ b/cam/encoder.go
@@ -54,58 +54,6 @@ func newEncoder(
 		frameCount: 0,
 		preset:     preset,
 	}
-	// codecID := lookupCodecIDByType(videoCodec)
-	// codec := C.avcodec_find_encoder(codecID)
-	// if codec == nil {
-	// 	return nil, errors.New("codec not found")
-	// }
-
-	// enc.codecCtx = C.avcodec_alloc_context3(codec)
-	// if enc.codecCtx == nil {
-	// 	return nil, errors.New("failed to allocate codec context")
-	// }
-
-	// enc.codecCtx.bit_rate = C.int64_t(bitrate)
-	// enc.codecCtx.pix_fmt = C.AV_PIX_FMT_YUV422P
-	// enc.codecCtx.time_base = C.AVRational{num: 1, den: C.int(framerate)}
-	// enc.codecCtx.width = C.int(width)
-	// enc.codecCtx.height = C.int(height)
-
-	// // TODO(seanp): Do we want b frames? This could make it more complicated to split clips.
-	// enc.codecCtx.max_b_frames = 0
-	// presetCStr := C.CString(preset)
-	// tuneCStr := C.CString("zerolatency")
-	// defer C.free(unsafe.Pointer(presetCStr))
-	// defer C.free(unsafe.Pointer(tuneCStr))
-
-	// // The user can set the preset and tune for the encoder. This affects the
-	// // encoding speed and quality. See https://trac.ffmpeg.org/wiki/Encode/H.264
-	// // for more information.
-	// var opts *C.AVDictionary
-	// defer C.av_dict_free(&opts)
-	// ret := C.av_dict_set(&opts, C.CString("preset"), presetCStr, 0)
-	// if ret < 0 {
-	// 	return nil, fmt.Errorf("av_dict_set failed: %s", ffmpegError(ret))
-	// }
-	// ret = C.av_dict_set(&opts, C.CString("tune"), tuneCStr, 0)
-	// if ret < 0 {
-	// 	return nil, fmt.Errorf("av_dict_set failed: %s", ffmpegError(ret))
-	// }
-
-	// ret = C.avcodec_open2(enc.codecCtx, codec, &opts)
-	// if ret < 0 {
-	// 	return nil, fmt.Errorf("avcodec_open2: %s", ffmpegError(ret))
-	// }
-
-	// srcFrame := C.av_frame_alloc()
-	// if srcFrame == nil {
-	// 	C.avcodec_close(enc.codecCtx)
-	// 	return nil, errors.New("could not allocate source frame")
-	// }
-	// srcFrame.width = enc.codecCtx.width
-	// srcFrame.height = enc.codecCtx.height
-	// srcFrame.format = C.int(enc.codecCtx.pix_fmt)
-	// enc.srcFrame = srcFrame
 
 	return enc, nil
 }

--- a/cam/segmenter.go
+++ b/cam/segmenter.go
@@ -66,9 +66,9 @@ func (s *segmenter) initialize(codecCtx *C.AVCodecContext) error {
 		if ret < 0 {
 			s.logger.Errorf("failed to write trailer", "error", ffmpegError(ret))
 		}
+		// This will also free the stream
 		C.avformat_free_context(s.outCtx)
 	}
-	// TODO(seanp): do we need to free the stream?
 
 	// Allocate output context for segmenter. The "segment" format is a special format
 	// that allows for segmenting output files. The output pattern is a strftime pattern

--- a/cam/segmenter.go
+++ b/cam/segmenter.go
@@ -29,64 +29,166 @@ type segmenter struct {
 	logger         logging.Logger
 	outCtx         *C.AVFormatContext
 	stream         *C.AVStream
-	encoder        *encoder
 	frameCount     int64
 	maxStorageSize int64
 	storagePath    string
+	clipLength     int
+	format         string
 }
 
 func newSegmenter(
 	logger logging.Logger,
-	enc *encoder,
+	// enc *encoder,
 	storageSize int,
 	clipLength int,
 	storagePath string,
 	format string,
 ) (*segmenter, error) {
 	s := &segmenter{
-		logger:  logger,
-		encoder: enc,
+		logger: logger,
+		// encoder: enc,
 	}
+	s.logger.Info("0")
 	s.maxStorageSize = int64(storageSize) * gigabyte
-
+	s.logger.Info("1")
+	s.clipLength = clipLength
 	s.storagePath = storagePath
+	s.format = format
+	s.logger.Info("2")
 	err := createDir(s.storagePath)
 	if err != nil {
 		return nil, err
 	}
-	outputPatternCStr := C.CString(storagePath + "/" + outputPattern)
-	defer C.free(unsafe.Pointer(outputPatternCStr))
+	s.logger.Info("3")
+	// outputPatternCStr := C.CString(storagePath + "/" + outputPattern)
+	// defer C.free(unsafe.Pointer(outputPatternCStr))
+
+	// // Allocate output context for segmenter. The "segment" format is a special format
+	// // that allows for segmenting output files. The output pattern is a strftime pattern
+	// // that specifies the output file name. The pattern is set to the current time.
+	// var fmtCtx *C.AVFormatContext
+	// ret := C.avformat_alloc_output_context2(&fmtCtx, nil, C.CString("segment"), outputPatternCStr)
+	// if ret < 0 {
+	// 	return nil, fmt.Errorf("failed to allocate output context: %s", ffmpegError(ret))
+	// }
+
+	// stream := C.avformat_new_stream(fmtCtx, nil)
+	// if stream == nil {
+	// 	return nil, errors.New("failed to allocate stream")
+	// }
+	// stream.id = C.int(fmtCtx.nb_streams) - 1
+	// stream.time_base = enc.codecCtx.time_base
+
+	// // Copy codec parameters from encoder to segment stream. This is equivalent to
+	// // -c:v copy in ffmpeg cli
+	// codecpar := C.avcodec_parameters_alloc()
+	// defer C.avcodec_parameters_free(&codecpar)
+	// if ret := C.avcodec_parameters_from_context(codecpar, enc.codecCtx); ret < 0 {
+	// 	return nil, fmt.Errorf("failed to copy codec parameters: %s", ffmpegError(ret))
+	// }
+	// ret = C.avcodec_parameters_copy(stream.codecpar, codecpar)
+	// if ret < 0 {
+	// 	return nil, fmt.Errorf("failed to copy codec parameters %s", ffmpegError(ret))
+	// }
+
+	// segmentLengthCStr := C.CString(strconv.Itoa(clipLength))
+	// segmentFormatCStr := C.CString(format)
+	// resetTimestampsCStr := C.CString("1")
+	// breakNonKeyFramesCStr := C.CString("1")
+	// strftimeCStr := C.CString("1")
+	// defer func() {
+	// 	C.free(unsafe.Pointer(segmentLengthCStr))
+	// 	C.free(unsafe.Pointer(segmentFormatCStr))
+	// 	C.free(unsafe.Pointer(resetTimestampsCStr))
+	// 	C.free(unsafe.Pointer(breakNonKeyFramesCStr))
+	// 	C.free(unsafe.Pointer(strftimeCStr))
+	// }()
+
+	// // Segment options are passed as opts to avformat_write_header. This only needs
+	// // to be done once, and not for every segment file.
+	// var opts *C.AVDictionary
+	// defer C.av_dict_free(&opts)
+	// ret = C.av_dict_set(&opts, C.CString("segment_time"), segmentLengthCStr, 0)
+	// if ret < 0 {
+	// 	return nil, fmt.Errorf("failed to set segment_time: %s", ffmpegError(ret))
+	// }
+	// ret = C.av_dict_set(&opts, C.CString("segment_format"), segmentFormatCStr, 0)
+	// if ret < 0 {
+	// 	return nil, fmt.Errorf("failed to set segment_format: %s", ffmpegError(ret))
+	// }
+	// ret = C.av_dict_set(&opts, C.CString("reset_timestamps"), resetTimestampsCStr, 0)
+	// if ret < 0 {
+	// 	return nil, fmt.Errorf("failed to set reset_timestamps: %s", ffmpegError(ret))
+	// }
+	// // TODO(seanp): Allowing this could cause flakey playback. Remove if not needed.
+	// // Or, fix by adding keyframe forces on the encoder side
+	// ret = C.av_dict_set(&opts, C.CString("break_non_keyframes"), breakNonKeyFramesCStr, 0)
+	// if ret < 0 {
+	// 	return nil, fmt.Errorf("failed to set break_non_keyframes: %s", ffmpegError(ret))
+	// }
+	// ret = C.av_dict_set(&opts, C.CString("strftime"), strftimeCStr, 0)
+	// if ret < 0 {
+	// 	return nil, fmt.Errorf("failed to set strftime: %s", ffmpegError(ret))
+	// }
+
+	// ret = C.avformat_write_header(fmtCtx, &opts)
+	// if ret < 0 {
+	// 	return nil, fmt.Errorf("failed to write header: %s", ffmpegError(ret))
+	// }
+
+	// // Writing header overwrites the time_base, so we need to reset it.
+	// // TODO(seanp): Figure out why this is necessary.
+	// stream.time_base = enc.codecCtx.time_base
+	// stream.id = C.int(fmtCtx.nb_streams) - 1
+	// s.stream = stream
+	// s.outCtx = fmtCtx
+
+	return s, nil
+}
+
+// initialize takes in a codec ctx and initializes the segmenter with the codec ctx.
+func (s *segmenter) initialize(codecCtx *C.AVCodecContext) error {
+	if s.outCtx != nil {
+		ret := C.av_write_trailer(s.outCtx)
+		if ret < 0 {
+			s.logger.Errorf("failed to write trailer", "error", ffmpegError(ret))
+		}
+		C.avformat_free_context(s.outCtx)
+	}
+	// TODO(seanp): do we need to free the stream?
 
 	// Allocate output context for segmenter. The "segment" format is a special format
 	// that allows for segmenting output files. The output pattern is a strftime pattern
 	// that specifies the output file name. The pattern is set to the current time.
+	outputPatternCStr := C.CString(s.storagePath + "/" + outputPattern)
+	defer C.free(unsafe.Pointer(outputPatternCStr))
 	var fmtCtx *C.AVFormatContext
 	ret := C.avformat_alloc_output_context2(&fmtCtx, nil, C.CString("segment"), outputPatternCStr)
 	if ret < 0 {
-		return nil, fmt.Errorf("failed to allocate output context: %s", ffmpegError(ret))
+		return fmt.Errorf("failed to allocate output context: %s", ffmpegError(ret))
 	}
 
 	stream := C.avformat_new_stream(fmtCtx, nil)
 	if stream == nil {
-		return nil, errors.New("failed to allocate stream")
+		return errors.New("failed to allocate stream")
 	}
 	stream.id = C.int(fmtCtx.nb_streams) - 1
-	stream.time_base = enc.codecCtx.time_base
+	stream.time_base = codecCtx.time_base
 
 	// Copy codec parameters from encoder to segment stream. This is equivalent to
 	// -c:v copy in ffmpeg cli
 	codecpar := C.avcodec_parameters_alloc()
 	defer C.avcodec_parameters_free(&codecpar)
-	if ret := C.avcodec_parameters_from_context(codecpar, enc.codecCtx); ret < 0 {
-		return nil, fmt.Errorf("failed to copy codec parameters: %s", ffmpegError(ret))
+	if ret := C.avcodec_parameters_from_context(codecpar, codecCtx); ret < 0 {
+		return fmt.Errorf("failed to copy codec parameters: %s", ffmpegError(ret))
 	}
 	ret = C.avcodec_parameters_copy(stream.codecpar, codecpar)
 	if ret < 0 {
-		return nil, fmt.Errorf("failed to copy codec parameters %s", ffmpegError(ret))
+		return fmt.Errorf("failed to copy codec parameters %s", ffmpegError(ret))
 	}
 
-	segmentLengthCStr := C.CString(strconv.Itoa(clipLength))
-	segmentFormatCStr := C.CString(format)
+	segmentLengthCStr := C.CString(strconv.Itoa(s.clipLength))
+	segmentFormatCStr := C.CString(s.format)
 	resetTimestampsCStr := C.CString("1")
 	breakNonKeyFramesCStr := C.CString("1")
 	strftimeCStr := C.CString("1")
@@ -104,44 +206,47 @@ func newSegmenter(
 	defer C.av_dict_free(&opts)
 	ret = C.av_dict_set(&opts, C.CString("segment_time"), segmentLengthCStr, 0)
 	if ret < 0 {
-		return nil, fmt.Errorf("failed to set segment_time: %s", ffmpegError(ret))
+		return fmt.Errorf("failed to set segment_time: %s", ffmpegError(ret))
 	}
 	ret = C.av_dict_set(&opts, C.CString("segment_format"), segmentFormatCStr, 0)
 	if ret < 0 {
-		return nil, fmt.Errorf("failed to set segment_format: %s", ffmpegError(ret))
+		return fmt.Errorf("failed to set segment_format: %s", ffmpegError(ret))
 	}
 	ret = C.av_dict_set(&opts, C.CString("reset_timestamps"), resetTimestampsCStr, 0)
 	if ret < 0 {
-		return nil, fmt.Errorf("failed to set reset_timestamps: %s", ffmpegError(ret))
+		return fmt.Errorf("failed to set reset_timestamps: %s", ffmpegError(ret))
 	}
 	// TODO(seanp): Allowing this could cause flakey playback. Remove if not needed.
 	// Or, fix by adding keyframe forces on the encoder side
 	ret = C.av_dict_set(&opts, C.CString("break_non_keyframes"), breakNonKeyFramesCStr, 0)
 	if ret < 0 {
-		return nil, fmt.Errorf("failed to set break_non_keyframes: %s", ffmpegError(ret))
+		return fmt.Errorf("failed to set break_non_keyframes: %s", ffmpegError(ret))
 	}
 	ret = C.av_dict_set(&opts, C.CString("strftime"), strftimeCStr, 0)
 	if ret < 0 {
-		return nil, fmt.Errorf("failed to set strftime: %s", ffmpegError(ret))
+		return fmt.Errorf("failed to set strftime: %s", ffmpegError(ret))
 	}
 
 	ret = C.avformat_write_header(fmtCtx, &opts)
 	if ret < 0 {
-		return nil, fmt.Errorf("failed to write header: %s", ffmpegError(ret))
+		return fmt.Errorf("failed to write header: %s", ffmpegError(ret))
 	}
 
 	// Writing header overwrites the time_base, so we need to reset it.
 	// TODO(seanp): Figure out why this is necessary.
-	stream.time_base = enc.codecCtx.time_base
+	stream.time_base = codecCtx.time_base
 	stream.id = C.int(fmtCtx.nb_streams) - 1
 	s.stream = stream
 	s.outCtx = fmtCtx
 
-	return s, nil
+	return nil
 }
 
 // writeEncodedFrame writes an encoded frame to the output segment file.
 func (s *segmenter) writeEncodedFrame(encodedData []byte, pts, dts int64) error {
+	if s.outCtx == nil {
+		return errors.New("segmenter not initialized")
+	}
 	pkt := C.AVPacket{
 		data:         (*C.uint8_t)(C.CBytes(encodedData)),
 		size:         C.int(len(encodedData)),

--- a/cam/segmenter.go
+++ b/cam/segmenter.go
@@ -44,8 +44,13 @@ func newSegmenter(
 	storagePath string,
 	format string,
 ) (*segmenter, error) {
+	// Initialize struct without stream or output context. We will initialize
+	// these when we get the first frame or when a resize is needed.
 	s := &segmenter{
 		logger:         logger,
+		outCtx:         nil,
+		stream:         nil,
+		frameCount:     0,
 		maxStorageSize: int64(storageSize) * gigabyte,
 		clipLength:     clipLength,
 		storagePath:    storagePath,
@@ -59,7 +64,7 @@ func newSegmenter(
 	return s, nil
 }
 
-// initialize takes in a codec ctx and initializes the segmenter with the codec ctx.
+// initialize takes in a codec ctx and initializes the segmenter with the codec parameters.
 func (s *segmenter) initialize(codecCtx *C.AVCodecContext) error {
 	if s.outCtx != nil {
 		ret := C.av_write_trailer(s.outCtx)

--- a/cam/segmenter.go
+++ b/cam/segmenter.go
@@ -45,103 +45,16 @@ func newSegmenter(
 	format string,
 ) (*segmenter, error) {
 	s := &segmenter{
-		logger: logger,
-		// encoder: enc,
+		logger:         logger,
+		maxStorageSize: int64(storageSize) * gigabyte,
+		clipLength:     clipLength,
+		storagePath:    storagePath,
+		format:         format,
 	}
-	s.logger.Info("0")
-	s.maxStorageSize = int64(storageSize) * gigabyte
-	s.logger.Info("1")
-	s.clipLength = clipLength
-	s.storagePath = storagePath
-	s.format = format
-	s.logger.Info("2")
 	err := createDir(s.storagePath)
 	if err != nil {
 		return nil, err
 	}
-	s.logger.Info("3")
-	// outputPatternCStr := C.CString(storagePath + "/" + outputPattern)
-	// defer C.free(unsafe.Pointer(outputPatternCStr))
-
-	// // Allocate output context for segmenter. The "segment" format is a special format
-	// // that allows for segmenting output files. The output pattern is a strftime pattern
-	// // that specifies the output file name. The pattern is set to the current time.
-	// var fmtCtx *C.AVFormatContext
-	// ret := C.avformat_alloc_output_context2(&fmtCtx, nil, C.CString("segment"), outputPatternCStr)
-	// if ret < 0 {
-	// 	return nil, fmt.Errorf("failed to allocate output context: %s", ffmpegError(ret))
-	// }
-
-	// stream := C.avformat_new_stream(fmtCtx, nil)
-	// if stream == nil {
-	// 	return nil, errors.New("failed to allocate stream")
-	// }
-	// stream.id = C.int(fmtCtx.nb_streams) - 1
-	// stream.time_base = enc.codecCtx.time_base
-
-	// // Copy codec parameters from encoder to segment stream. This is equivalent to
-	// // -c:v copy in ffmpeg cli
-	// codecpar := C.avcodec_parameters_alloc()
-	// defer C.avcodec_parameters_free(&codecpar)
-	// if ret := C.avcodec_parameters_from_context(codecpar, enc.codecCtx); ret < 0 {
-	// 	return nil, fmt.Errorf("failed to copy codec parameters: %s", ffmpegError(ret))
-	// }
-	// ret = C.avcodec_parameters_copy(stream.codecpar, codecpar)
-	// if ret < 0 {
-	// 	return nil, fmt.Errorf("failed to copy codec parameters %s", ffmpegError(ret))
-	// }
-
-	// segmentLengthCStr := C.CString(strconv.Itoa(clipLength))
-	// segmentFormatCStr := C.CString(format)
-	// resetTimestampsCStr := C.CString("1")
-	// breakNonKeyFramesCStr := C.CString("1")
-	// strftimeCStr := C.CString("1")
-	// defer func() {
-	// 	C.free(unsafe.Pointer(segmentLengthCStr))
-	// 	C.free(unsafe.Pointer(segmentFormatCStr))
-	// 	C.free(unsafe.Pointer(resetTimestampsCStr))
-	// 	C.free(unsafe.Pointer(breakNonKeyFramesCStr))
-	// 	C.free(unsafe.Pointer(strftimeCStr))
-	// }()
-
-	// // Segment options are passed as opts to avformat_write_header. This only needs
-	// // to be done once, and not for every segment file.
-	// var opts *C.AVDictionary
-	// defer C.av_dict_free(&opts)
-	// ret = C.av_dict_set(&opts, C.CString("segment_time"), segmentLengthCStr, 0)
-	// if ret < 0 {
-	// 	return nil, fmt.Errorf("failed to set segment_time: %s", ffmpegError(ret))
-	// }
-	// ret = C.av_dict_set(&opts, C.CString("segment_format"), segmentFormatCStr, 0)
-	// if ret < 0 {
-	// 	return nil, fmt.Errorf("failed to set segment_format: %s", ffmpegError(ret))
-	// }
-	// ret = C.av_dict_set(&opts, C.CString("reset_timestamps"), resetTimestampsCStr, 0)
-	// if ret < 0 {
-	// 	return nil, fmt.Errorf("failed to set reset_timestamps: %s", ffmpegError(ret))
-	// }
-	// // TODO(seanp): Allowing this could cause flakey playback. Remove if not needed.
-	// // Or, fix by adding keyframe forces on the encoder side
-	// ret = C.av_dict_set(&opts, C.CString("break_non_keyframes"), breakNonKeyFramesCStr, 0)
-	// if ret < 0 {
-	// 	return nil, fmt.Errorf("failed to set break_non_keyframes: %s", ffmpegError(ret))
-	// }
-	// ret = C.av_dict_set(&opts, C.CString("strftime"), strftimeCStr, 0)
-	// if ret < 0 {
-	// 	return nil, fmt.Errorf("failed to set strftime: %s", ffmpegError(ret))
-	// }
-
-	// ret = C.avformat_write_header(fmtCtx, &opts)
-	// if ret < 0 {
-	// 	return nil, fmt.Errorf("failed to write header: %s", ffmpegError(ret))
-	// }
-
-	// // Writing header overwrites the time_base, so we need to reset it.
-	// // TODO(seanp): Figure out why this is necessary.
-	// stream.time_base = enc.codecCtx.time_base
-	// stream.id = C.int(fmtCtx.nb_streams) - 1
-	// s.stream = stream
-	// s.outCtx = fmtCtx
 
 	return s, nil
 }

--- a/cam/segmenter.go
+++ b/cam/segmenter.go
@@ -38,7 +38,6 @@ type segmenter struct {
 
 func newSegmenter(
 	logger logging.Logger,
-	// enc *encoder,
 	storageSize int,
 	clipLength int,
 	storagePath string,

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -100,11 +100,7 @@ func TestModuleConfiguration(t *testing.T) {
 						"upload_path": "%s",
 						"storage_path": "%s"
 					},
-					"cam_props": {
-						"width": 1280,
-						"height": 720,
-						"framerate": 30
-					},
+					"framerate": 30,
 					"video": {
 						"codec": "h264",
 						"bitrate": 1000000,
@@ -206,11 +202,7 @@ func TestModuleConfiguration(t *testing.T) {
 				"attributes": {
 					"camera": "fake-cam-1",
 					"sync": "data_manager-1",
-					"cam_props": {
-						"width": 1280,
-						"height": 720,
-						"framerate": 30
-					},
+					"framerate": 30,
 					"video": {
 						"codec": "h264",
 						"bitrate": 1000000,
@@ -272,11 +264,7 @@ func TestModuleConfiguration(t *testing.T) {
 						"upload_path": "/tmp/video-upload",
 						"storage_path": "/tmp/video-storage"
 					},
-					"cam_props": {
-						"width": 1280,
-						"height": 720,
-						"framerate": 30
-					},
+					"framerate": 30,
 					"video": {
 						"codec": "h264",
 						"bitrate": 1000000,
@@ -321,7 +309,7 @@ func TestModuleConfiguration(t *testing.T) {
 		]
 	}`, fullModuleBinPath)
 
-	// cam_props NOT specified
+	// framerate NOT specified
 	config5 := fmt.Sprintf(`
 	{
 		"components": [
@@ -400,11 +388,7 @@ func TestModuleConfiguration(t *testing.T) {
 						"upload_path": "/tmp",
 						"storage_path": "/tmp"
 					},
-					"cam_props": {
-						"width": 1280,
-						"height": 720,
-						"framerate": 30
-					},
+					"framerate": 30,
 					"video": {
 						"codec": "h264",
 						"bitrate": 1000000,
@@ -483,7 +467,7 @@ func TestModuleConfiguration(t *testing.T) {
 		test.That(t, err.Error(), test.ShouldContainSubstring, "size_gb")
 	})
 
-	t.Run("No CamProps succeeds with defaults", func(t *testing.T) {
+	t.Run("No framerate Succeeds", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 		r, err := setupViamServer(timeoutCtx, config5)

--- a/tests/fetch_test.go
+++ b/tests/fetch_test.go
@@ -34,11 +34,7 @@ func TestFetchDoCommand(t *testing.T) {
 						"upload_path": "%s",
 						"storage_path": "%s"
 					},
-					"cam_props": {
-						"width": 1280,
-						"height": 720,
-						"framerate": 30
-					},
+					"framerate": 30,
 					"video": {
 						"codec": "h264",
 						"bitrate": 1000000,

--- a/tests/save_test.go
+++ b/tests/save_test.go
@@ -35,11 +35,7 @@ func TestSaveDoCommand(t *testing.T) {
 						"upload_path": "%s",
 						"storage_path": "%s"
 					},
-					"cam_props": {
-						"width": 1280,
-						"height": 720,
-						"framerate": 30
-					},
+					"framerate": 30,
 					"video": {
 						"codec": "h264",
 						"bitrate": 1000000,


### PR DESCRIPTION
## Description

This addresses crashes in the encoder downstream from mismatches between the actual frames received from the source camera and the encoder/segmenter parameters. We now defer initialization of the encoder and segmenter until we receive a frame and can reinitialize when the dimensions change. If the Image endpoint of the source camera changes we will spin off a new initialization flow to handle the new size.


Beforehand you can reliably repro a crash with wildly off `cam_props`. For instance, the following parameters with a 640x480 source camera.

```
        "cam_props": {
          "height": 10,
          "framerate": 20,
          "width": 10000
        }
        
```

Will show the following segfault trace:

```
\_ Assertion ((src_linesize) >= 0 ? (src_linesize) : (-(src_linesize))) >= bytewidth failed at libavutil/imgutils.c:350
2025-01-10T17:19:11.749Z        ERROR   rdk.modmanager.viam_video-store.viam_video-store.StdErr pexec/managed_process.go:277
\_ SIGABRT: abort
2025-01-10T17:19:11.750Z        ERROR   rdk.modmanager.viam_video-store.viam_video-store.StdErr pexec/managed_process.go:277
\_ PC=0x7fbc044e6c m=9 sigcode=18446744073709551610  
2025-01-10T17:19:11.750Z        ERROR   rdk.modmanager.viam_video-store.viam_video-store.StdErr pexec/managed_process.go:277
\_ signal arrived during cgo execution
2025-01-10T17:19:11.750Z        ERROR   rdk.modmanager.viam_video-store.viam_video-store.StdErr pexec/managed_process.go:277
\_

....

```

## Tests
- Adjusted config tests for new setup without cam_props and optoinal framerate property.
- Manually tested a changing source RTSP camera.
  - Verify that current segment ends on size change trigger ✅ 
  - Verify that next segment at adjusted size is playable ✅ 
  - Verify multiple size change events work ✅ 
  
  
  ```
  {
  "components": [
    {
      "name": "video-store",
      "model": "viam:video:storage",
      "attributes": {
        "sync": "data_manager-1",
        "storage": {
          "segment_seconds": 10,
          "upload_path": "/home/viam/.viam/video-upload-test",
          "size_gb": 10
        },
        "cam_props": {
          "width": 10000,
          "height": 10,
          "framerate": 20
        },
        "video": {
          "preset": "ultrafast"
        },
        "camera": "rtsp-cam-1"
      },
      "depends_on": [
        "rtsp-cam-1",
        "data_manager-1"
      ],
      "namespace": "rdk",
      "type": "camera"
    },
    {
      "name": "rtsp-cam-1",
      "model": "viam:viamrtsp:rtsp",
      "attributes": {
        "rtsp_address": "rtsp://admin:GOSTadm1n@10.1.12.67:554/cam/realmonitor?channel=2&subtype=0&unicast=true&proto=Onvif",
        "rtp_passthrough": true
      },
      "namespace": "rdk",
      "type": "camera"
    }
  ],
  "services": [
    {
      "name": "data_manager-1",
      "attributes": {
        "sync_interval_mins": 0.1,
        "capture_dir": "",
        "tags": [],
        "additional_sync_paths": [],
        "capture_disabled": true
      },
      "namespace": "rdk",
      "type": "data_manager"
    }
  ],
  "modules": [
    {
      "type": "registry",
      "name": "viam_viamrtsp",
      "module_id": "viam:viamrtsp",
      "version": "0.2.0-rc4"
    },
    {
      "executable_path": "/home/viam/video-store-no-cam-props-review",
      "name": "viam_video-store",
      "type": "local"
    }
  ]
}
```