### PR TITLE
[RSDK-9701] - Add YUYV mimetype handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ ifeq ($(shell which artifact > /dev/null 2>&1; echo $$?), 1)
 endif
 	artifact pull
 	cp $(BIN_OUTPUT_PATH)/video-store bin/video-store
-	go test -v ./tests/
+	go test -v ./tests/... ./cam/...
 	rm bin/video-store
 
 module: $(BIN_OUTPUT_PATH)/video-store

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ ifeq ($(shell which artifact > /dev/null 2>&1; echo $$?), 1)
 endif
 	artifact pull
 	cp $(BIN_OUTPUT_PATH)/video-store bin/video-store
-	go test -v ./tests/... ./cam/...
+	go test -v ./tests/ ./cam/
 	rm bin/video-store
 
 module: $(BIN_OUTPUT_PATH)/video-store

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ ifeq ($(shell which artifact > /dev/null 2>&1; echo $$?), 1)
 endif
 	artifact pull
 	cp $(BIN_OUTPUT_PATH)/video-store bin/video-store
-	go test -v ./tests/ ./cam/
+	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS=$(CGO_CFLAGS) go test -v ./tests/ ./cam/
 	rm bin/video-store
 
 module: $(BIN_OUTPUT_PATH)/video-store

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ FFMPEG_OPTS ?= --prefix=$(FFMPEG_BUILD) \
                --enable-protocol=file \
                --enable-protocol=concat \
                --enable-protocol=crypto \
-               --enable-bsf=h264_mp4toannexb
+               --enable-bsf=h264_mp4toannexb \
+               --enable-decoder=mjpeg
 
 CGO_LDFLAGS := -L$(FFMPEG_BUILD)/lib -lavcodec -lavutil -lavformat -lswscale -lz
 ifeq ($(SOURCE_OS),linux)

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ FFMPEG_OPTS ?= --prefix=$(FFMPEG_BUILD) \
                --enable-protocol=crypto \
                --enable-bsf=h264_mp4toannexb
 
-CGO_LDFLAGS := -L$(FFMPEG_BUILD)/lib -lavcodec -lavutil -lavformat -lz
+CGO_LDFLAGS := -L$(FFMPEG_BUILD)/lib -lavcodec -lavutil -lavformat -lswscale -lz
 ifeq ($(SOURCE_OS),linux)
 	CGO_LDFLAGS += -l:libx264.a
 endif

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Additionally, make sure to add your configured data manager service to the `depe
 |                 | `bitrate`         | integer | optional  | Throughput of encoder in bits per second. Higher for better quality video, and lower for better storage efficiency. |
 |                 | `preset`          | string  | optional  | Name of codec video preset to use. See [here](https://trac.ffmpeg.org/wiki/Encode/H.264#a2.Chooseapresetandtune) for preset options.                                                                |
 | `framerate`     |                   | integer | optional  | Frame rate of the video in frames per second. Default value is 20 if not set.                      |
+| `yuyv`          |                   | bool    | optional  | Flag to request an "image/yuyv422" MIME type.                                                     |
 
 ### Example Configuration
 

--- a/cam/cam.go
+++ b/cam/cam.go
@@ -58,9 +58,7 @@ type videostore struct {
 	logger logging.Logger
 
 	cam camera.Camera
-	// latestFrame atomic.Pointer[image.Image]
-	// latestFrame atomic.Pointer[[]byte]
-	// latestframe as avframe
+
 	latestFrame atomic.Pointer[C.AVFrame]
 
 	workers *utils.StoppableWorkers
@@ -370,9 +368,6 @@ func (vs *videostore) fetchFrames(ctx context.Context) {
 			var frame *C.AVFrame
 			switch metadata.MimeType {
 			case mimeTypeYUYV, mimeTypeYUYV + "+" + rutils.MimeTypeSuffixLazy:
-				// We need to extract width and height somehow,
-				// either threw custom header or adding to metadata response.
-				// For now, we will assume width and height are known.
 				vs.logger.Info("converting yuyv422 to yuv420p")
 				// frame, err = vs.mh.yuyvToYUV420p(bytes, 352, 240) //nolint
 				frame, err = vs.mh.yuyvToYUV420p(bytes)

--- a/cam/cam.go
+++ b/cam/cam.go
@@ -368,15 +368,12 @@ func (vs *videostore) fetchFrames(ctx context.Context) {
 			var frame *C.AVFrame
 			switch metadata.MimeType {
 			case mimeTypeYUYV, mimeTypeYUYV + "+" + rutils.MimeTypeSuffixLazy:
-				vs.logger.Info("converting yuyv422 to yuv420p")
-				// frame, err = vs.mh.yuyvToYUV420p(bytes, 352, 240) //nolint
 				frame, err = vs.mh.yuyvToYUV420p(bytes)
 				if err != nil {
 					vs.logger.Error("failed to convert yuyv422 to yuv420p", err)
 					continue
 				}
 			case rutils.MimeTypeJPEG, rutils.MimeTypeJPEG + "+" + rutils.MimeTypeSuffixLazy:
-				vs.logger.Info("converting jpeg to yuv420p")
 				frame, err = vs.mh.decodeJPEG(bytes)
 				if err != nil {
 					vs.logger.Error("failed to decode jpeg", err)

--- a/cam/cam.go
+++ b/cam/cam.go
@@ -57,11 +57,9 @@ type videostore struct {
 	conf   *Config
 	logger logging.Logger
 
-	cam camera.Camera
-
+	cam         camera.Camera
 	latestFrame atomic.Pointer[C.AVFrame]
-
-	workers *utils.StoppableWorkers
+	workers     *utils.StoppableWorkers
 
 	enc  *encoder
 	mh   *mimeHandler

--- a/cam/cam.go
+++ b/cam/cam.go
@@ -374,7 +374,8 @@ func (vs *videostore) fetchFrames(ctx context.Context) {
 				// either threw custom header or adding to metadata response.
 				// For now, we will assume width and height are known.
 				vs.logger.Info("converting yuyv422 to yuv420p")
-				frame, err = vs.mh.yuyvToYUV420p(bytes, 352, 240) //nolint
+				// frame, err = vs.mh.yuyvToYUV420p(bytes, 352, 240) //nolint
+				frame, err = vs.mh.yuyvToYUV420p(bytes)
 				if err != nil {
 					vs.logger.Error("failed to convert yuyv422 to yuv420p", err)
 					continue

--- a/cam/encoder.go
+++ b/cam/encoder.go
@@ -96,6 +96,8 @@ func (e *encoder) initialize(width, height int) (err error) {
 		return errors.New("failed to allocate codec context")
 	}
 	e.codecCtx.bit_rate = C.int64_t(e.bitrate)
+	// We are choosing YUV20p here as the input to the encoder
+	// so that the same format can be used between JPEG decodes and YUYV conversions.
 	e.codecCtx.pix_fmt = C.AV_PIX_FMT_YUV420P
 	e.codecCtx.time_base = C.AVRational{num: 1, den: C.int(e.framerate)}
 	e.codecCtx.width = C.int(width)

--- a/cam/encoder.go
+++ b/cam/encoder.go
@@ -96,7 +96,6 @@ func (e *encoder) initialize(width, height int) (err error) {
 		return errors.New("failed to allocate codec context")
 	}
 	e.codecCtx.bit_rate = C.int64_t(e.bitrate)
-	// e.codecCtx.pix_fmt = C.AV_PIX_FMT_YUV422P
 	e.codecCtx.pix_fmt = C.AV_PIX_FMT_YUV420P
 	e.codecCtx.time_base = C.AVRational{num: 1, den: C.int(e.framerate)}
 	e.codecCtx.width = C.int(width)
@@ -141,7 +140,6 @@ func (e *encoder) initialize(width, height int) (err error) {
 // PTS is calculated based on the frame count and source framerate.
 // If the polling loop is not running at the source framerate, the
 // PTS will lag behind actual run time.
-// func (e *encoder) encode(frame image.Image) (encodeResult, error) {
 func (e *encoder) encode(frame *C.AVFrame) (encodeResult, error) {
 	result := encodeResult{
 		encodedData:      nil,

--- a/cam/mime.go
+++ b/cam/mime.go
@@ -21,6 +21,8 @@ type mimeHandler struct {
 	yuyvSrcFrame *C.AVFrame
 	yuyvDstFrame *C.AVFrame
 	yuyvSwCtx    *C.struct_SwsContext
+	jpegDstFrame *C.AVFrame
+	jpegCodecCtx *C.AVCodecContext
 }
 
 func newMimeHandler(logger logging.Logger) *mimeHandler {
@@ -106,6 +108,89 @@ func (mh *mimeHandler) initYUYVCtx(width, height int) error {
 
 	return nil
 }
+
+func (mh *mimeHandler) decodeJPEG(frameBytes []byte) (*C.AVFrame, error) {
+	// fill a jpeg pkt with the frame bytes
+	dataPtr := C.CBytes(frameBytes)
+	defer C.free(dataPtr)
+	pkt := C.AVPacket{
+		data: (*C.uint8_t)(dataPtr),
+		size: C.int(len(frameBytes)),
+	}
+	// defer free the pkt data
+	if mh.jpegCodecCtx == nil {
+		if err := mh.initJPEGDecoder(); err != nil {
+			return nil, err
+		}
+	}
+	if mh.jpegCodecCtx == nil {
+		return nil, errors.New("JPEG decoder not initialized")
+	}
+	// Allocate the destination frame if not already allocated
+	if mh.jpegDstFrame == nil {
+		mh.jpegDstFrame = C.av_frame_alloc()
+		if mh.jpegDstFrame == nil {
+			return nil, errors.New("could not allocate destination frame")
+		}
+	}
+	// The mjpeg decoder can figure out width and height from the frame bytes.
+	// We don't need to pass width and height to initJPEGDecoder and it can
+	// recover from a change in resolution.
+	ret := C.avcodec_send_packet(mh.jpegCodecCtx, &pkt)
+	if ret < 0 {
+		return nil, errors.New("failed to send packet to JPEG decoder")
+	}
+	// Receive frame will allocate the frame buffer so we do not need to
+	// manually call av_frame_get_buffer.
+	ret = C.avcodec_receive_frame(mh.jpegCodecCtx, mh.jpegDstFrame)
+	if ret < 0 {
+		return nil, errors.New("failed to receive frame from JPEG decoder")
+	}
+
+	return mh.jpegDstFrame, nil
+}
+
+func (mh *mimeHandler) initJPEGDecoder() error {
+	mh.logger.Infof("Initializing JPEG decoder")
+	if mh.jpegCodecCtx != nil {
+		C.avcodec_free_context(&mh.jpegCodecCtx)
+	}
+	if mh.jpegDstFrame != nil {
+		C.av_frame_free(&mh.jpegDstFrame)
+	}
+
+	// initialize codec context
+	codec := C.avcodec_find_decoder(C.AV_CODEC_ID_MJPEG)
+	if codec == nil {
+		return errors.New("failed to find JPEG codec")
+	}
+	mh.jpegCodecCtx = C.avcodec_alloc_context3(codec)
+	if mh.jpegCodecCtx == nil {
+		return errors.New("failed to allocate JPEG codec context")
+	}
+	mh.jpegCodecCtx.pix_fmt = C.AV_PIX_FMT_YUV420P
+	ret := C.avcodec_open2(mh.jpegCodecCtx, codec, nil)
+	if ret < 0 {
+		return errors.New("failed to open JPEG codec")
+	}
+
+	return nil
+}
+
+/*
+	// initialize the destination frame
+	mh.jpegDstFrame = C.av_frame_alloc()
+	if mh.jpegDstFrame == nil {
+		return errors.New("failed to allocate JPEG destination frame")
+	}
+	mh.jpegDstFrame.width = C.int(width)
+	mh.jpegDstFrame.height = C.int(height)
+	mh.jpegDstFrame.format = C.AV_PIX_FMT_YUV420P
+	ret = C.av_frame_get_buffer(mh.jpegDstFrame, 32)
+	if ret < 0 {
+		return errors.New("failed to allocate buffer for JPEG destination frame")
+	}
+*/
 
 func (mh *mimeHandler) close() {
 	if mh.yuyvSwCtx != nil {

--- a/cam/mime.go
+++ b/cam/mime.go
@@ -79,7 +79,6 @@ func (mh *mimeHandler) initYUYVCtx(width, height int) error {
 	if mh.yuyvSrcFrame != nil {
 		C.av_frame_free(&mh.yuyvSrcFrame)
 	}
-
 	mh.yuyvSwCtx = C.sws_getContext(C.int(width), C.int(height), C.AV_PIX_FMT_YUYV422,
 		C.int(width), C.int(height), C.AV_PIX_FMT_YUV420P,
 		C.SWS_FAST_BILINEAR, nil, nil, nil)
@@ -94,7 +93,6 @@ func (mh *mimeHandler) initYUYVCtx(width, height int) error {
 	mh.yuyvSrcFrame.width = C.int(width)
 	mh.yuyvSrcFrame.height = C.int(height)
 	mh.yuyvSrcFrame.format = C.AV_PIX_FMT_YUYV422
-	// allocate buffer for YUYV data
 	ret := C.av_frame_get_buffer(mh.yuyvSrcFrame, 32)
 	if ret < 0 {
 		return errors.New("failed to allocate buffer for YUYV source frame")

--- a/cam/mime.go
+++ b/cam/mime.go
@@ -1,0 +1,120 @@
+package videostore
+
+/*
+#include <libavcodec/avcodec.h>
+#include <libavutil/frame.h>
+#include <libswscale/swscale.h>
+#include <libavutil/error.h>
+#include <libavutil/opt.h>
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"errors"
+
+	"go.viam.com/rdk/logging"
+)
+
+type mimeHandler struct {
+	logger       logging.Logger
+	yuyvSrcFrame *C.AVFrame
+	yuyvDstFrame *C.AVFrame
+	yuyvSwCtx    *C.struct_SwsContext
+}
+
+func newMimeHandler(logger logging.Logger) *mimeHandler {
+	return &mimeHandler{
+		logger: logger,
+	}
+}
+
+func (mh *mimeHandler) yuyvToYUV420p(frameBytes []byte, width, height int) (*C.AVFrame, error) {
+	if mh.yuyvSwCtx == nil || width != int(mh.yuyvDstFrame.width) || height != int(mh.yuyvDstFrame.height) {
+		if err := mh.initYUYVCtx(width, height); err != nil {
+			return nil, err
+		}
+	}
+
+	// Fill src frame with YUYV data bytes.
+	// We use C.CBytes to allocate memory in C heap and defer free it.
+	yuyvBytes := C.CBytes(frameBytes)
+	defer C.free(yuyvBytes)
+	mh.yuyvSrcFrame.data[0] = (*C.uint8_t)(yuyvBytes)
+	mh.yuyvSrcFrame.linesize[0] = C.int(width * subsampleFactor)
+
+	// Convert YUYV to YUV420p.
+	ret := C.sws_scale(
+		mh.yuyvSwCtx,
+		&mh.yuyvSrcFrame.data[0],
+		&mh.yuyvSrcFrame.linesize[0],
+		0,
+		C.int(height),
+		&mh.yuyvDstFrame.data[0],
+		&mh.yuyvDstFrame.linesize[0],
+	)
+	if ret < 0 {
+		return nil, errors.New("failed to convert YUYV to YUV420p")
+	}
+
+	return mh.yuyvDstFrame, nil
+}
+
+func (mh *mimeHandler) initYUYVCtx(width, height int) error {
+	mh.logger.Infof("Initializing YUYV sws context with width %d and height %d", width, height)
+	if mh.yuyvSwCtx != nil {
+		C.sws_freeContext(mh.yuyvSwCtx)
+	}
+	if mh.yuyvDstFrame != nil {
+		C.av_frame_free(&mh.yuyvDstFrame)
+	}
+	if mh.yuyvSrcFrame != nil {
+		C.av_frame_free(&mh.yuyvSrcFrame)
+	}
+
+	mh.yuyvSwCtx = C.sws_getContext(C.int(width), C.int(height), C.AV_PIX_FMT_YUYV422,
+		C.int(width), C.int(height), C.AV_PIX_FMT_YUV420P,
+		C.SWS_FAST_BILINEAR, nil, nil, nil)
+	if mh.yuyvSwCtx == nil {
+		return errors.New("failed to create YUYV to YUV420p conversion context")
+	}
+
+	mh.yuyvSrcFrame = C.av_frame_alloc()
+	if mh.yuyvSrcFrame == nil {
+		return errors.New("failed to allocate YUYV source frame")
+	}
+	mh.yuyvSrcFrame.width = C.int(width)
+	mh.yuyvSrcFrame.height = C.int(height)
+	mh.yuyvSrcFrame.format = C.AV_PIX_FMT_YUYV422
+	// allocate buffer for YUYV data
+	ret := C.av_frame_get_buffer(mh.yuyvSrcFrame, 32)
+	if ret < 0 {
+		return errors.New("failed to allocate buffer for YUYV source frame")
+	}
+
+	mh.yuyvDstFrame = C.av_frame_alloc()
+	if mh.yuyvDstFrame == nil {
+		return errors.New("failed to allocate YUV420p destination frame")
+	}
+	mh.yuyvDstFrame.width = C.int(width)
+	mh.yuyvDstFrame.height = C.int(height)
+	mh.yuyvDstFrame.format = C.AV_PIX_FMT_YUV420P
+	ret = C.av_frame_get_buffer(mh.yuyvDstFrame, 32)
+	if ret < 0 {
+		return errors.New("failed to allocate buffer for YUV420p destination frame")
+	}
+
+	return nil
+}
+
+func (mh *mimeHandler) close() {
+	if mh.yuyvSwCtx != nil {
+		C.sws_freeContext(mh.yuyvSwCtx)
+	}
+	if mh.yuyvDstFrame != nil {
+		C.av_frame_free(&mh.yuyvDstFrame)
+	}
+	if mh.yuyvSrcFrame != nil {
+		C.av_frame_free(&mh.yuyvSrcFrame)
+	}
+}

--- a/cam/mime.go
+++ b/cam/mime.go
@@ -13,13 +13,15 @@ import "C"
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 
 	"go.viam.com/rdk/logging"
 )
 
 const (
-	yuyvHeaderSize  = 12
-	yuyvMagicString = "YUYV"
+	yuyvHeaderSize    = 12
+	yuyvMagicString   = "YUYV"
+	yuyvBytesPerPixel = 2
 )
 
 type mimeHandler struct {
@@ -206,6 +208,10 @@ func parseYUYVPacket(pkt []byte) (int, int, []byte, error) {
 	width := int(binary.BigEndian.Uint32(pkt[4:8]))
 	height := int(binary.BigEndian.Uint32(pkt[8:12]))
 	yuyvData := pkt[12:]
+	expectedLength := width * height * yuyvBytesPerPixel
+	if len(yuyvData) != expectedLength {
+		return 0, 0, nil, fmt.Errorf("unexpected YUYV data length, expected %d, got %d", expectedLength, len(yuyvData))
+	}
 
 	return width, height, yuyvData, nil
 }

--- a/cam/mime.go
+++ b/cam/mime.go
@@ -69,7 +69,7 @@ func (mh *mimeHandler) yuyvToYUV420p(bytes []byte) (*C.AVFrame, error) {
 }
 
 func (mh *mimeHandler) initYUYVCtx(width, height int) error {
-	mh.logger.Infof("Initializing YUYV sws context with width %d and height %d", width, height)
+	mh.logger.Infof("initializing YUYV sws context with width %d and height %d", width, height)
 	if mh.yuyvSwCtx != nil {
 		C.sws_freeContext(mh.yuyvSwCtx)
 	}
@@ -156,7 +156,7 @@ func (mh *mimeHandler) decodeJPEG(frameBytes []byte) (*C.AVFrame, error) {
 }
 
 func (mh *mimeHandler) initJPEGDecoder() error {
-	mh.logger.Infof("Initializing JPEG decoder")
+	mh.logger.Infof("initializing JPEG decoder")
 	if mh.jpegCodecCtx != nil {
 		C.avcodec_free_context(&mh.jpegCodecCtx)
 	}

--- a/cam/mime_test.go
+++ b/cam/mime_test.go
@@ -1,0 +1,84 @@
+package videostore
+
+import (
+	"bytes"
+	"encoding/binary"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"testing"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/test"
+)
+
+func createDummyJPEG() ([]byte, error) {
+	img := image.NewRGBA(image.Rect(0, 0, 100, 100))
+	for x := range 100 {
+		for y := range 100 {
+			img.Set(x, y, color.RGBA{255, 0, 0, 255}) // Red color
+		}
+	}
+	var buf bytes.Buffer
+	err := jpeg.Encode(&buf, img, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func createDummyYUYVPacket(width, height int) []byte {
+	header := make([]byte, 12)
+	copy(header[0:4], []byte("YUYV"))
+	binary.BigEndian.PutUint32(header[4:8], uint32(width))
+	binary.BigEndian.PutUint32(header[8:12], uint32(height))
+	dataLen := width * height * 2
+	yuyvData := make([]byte, dataLen)
+	for i := 0; i < dataLen; i += 4 {
+		yuyvData[i+0] = 0x80 // U
+		yuyvData[i+1] = 0x10 // Y
+		yuyvData[i+2] = 0x80 // V
+		yuyvData[i+3] = 0x10 // Y
+	}
+
+	return append(header, yuyvData...)
+}
+
+func TestJPEGDecode(t *testing.T) {
+	jpegBytes, err := createDummyJPEG()
+	test.That(t, err, test.ShouldBeNil)
+	logger := logging.NewLogger("test")
+	mh := newMimeHandler(logger)
+	t.Run("JPEG Decode succeeds with valid JPEG bytes", func(t *testing.T) {
+		frame, err := mh.decodeJPEG(jpegBytes)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, frame, test.ShouldNotBeNil)
+	})
+
+	t.Run("JPEG Decode fails with invalid JPEG bytes", func(t *testing.T) {
+		frame, err := mh.decodeJPEG([]byte("invalid jpeg bytes"))
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "ailed to send packet to JPEG decoder")
+		test.That(t, frame, test.ShouldBeNil)
+	})
+}
+
+func TestYUYVToYUV420p(t *testing.T) {
+	// create dummy YUYV bytes
+	yuyvBytes := createDummyYUYVPacket(100, 100)
+	logger := logging.NewLogger("test")
+	mh := newMimeHandler(logger)
+	t.Run("YUYV to YUV420p succeeds with valid YUYV bytes", func(t *testing.T) {
+		frame, err := mh.yuyvToYUV420p(yuyvBytes)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, frame, test.ShouldNotBeNil)
+	})
+
+	t.Run("YUYV to YUV420p fails with invalid header", func(t *testing.T) {
+		frame, err := mh.yuyvToYUV420p([]byte("invalid yuyv bytes"))
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "missing 'YUYV' magic bytes")
+		test.That(t, frame, test.ShouldBeNil)
+	})
+}

--- a/cam/mime_test.go
+++ b/cam/mime_test.go
@@ -54,25 +54,28 @@ func TestJPEGDecode(t *testing.T) {
 		frame, err := mh.decodeJPEG(jpegBytes)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, frame, test.ShouldNotBeNil)
+		test.That(t, frame.data[0], test.ShouldNotBeNil)
 	})
 
 	t.Run("JPEG Decode fails with invalid JPEG bytes", func(t *testing.T) {
 		frame, err := mh.decodeJPEG([]byte("invalid jpeg bytes"))
 		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "ailed to send packet to JPEG decoder")
+		test.That(t, err.Error(), test.ShouldContainSubstring, "failed to send packet to JPEG decoder")
 		test.That(t, frame, test.ShouldBeNil)
 	})
 }
 
 func TestYUYVToYUV420p(t *testing.T) {
-	// create dummy YUYV bytes
-	yuyvBytes := createDummyYUYVPacket(100, 100)
+	width := 100
+	height := 100
+	yuyvBytes := createDummyYUYVPacket(width, height)
 	logger := logging.NewLogger("test")
 	mh := newMimeHandler(logger)
 	t.Run("YUYV to YUV420p succeeds with valid YUYV bytes", func(t *testing.T) {
 		frame, err := mh.yuyvToYUV420p(yuyvBytes)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, frame, test.ShouldNotBeNil)
+		test.That(t, frame.data[0], test.ShouldNotBeNil)
 	})
 
 	t.Run("YUYV to YUV420p fails with invalid header", func(t *testing.T) {
@@ -80,5 +83,13 @@ func TestYUYVToYUV420p(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "missing 'YUYV' magic bytes")
 		test.That(t, frame, test.ShouldBeNil)
+	})
+
+	t.Run("Test that header width and height are scraped correctly", func(t *testing.T) {
+		frame, err := mh.yuyvToYUV420p(yuyvBytes)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, frame, test.ShouldNotBeNil)
+		test.That(t, frame.width, test.ShouldEqual, width)
+		test.That(t, frame.height, test.ShouldEqual, height)
 	})
 }


### PR DESCRIPTION
## Description

This PR adds YUYV mime type handling for more efficient frame fetching from viamrtsp.
- Adds an optionsl attribute `yuyv` to flag we want to fetch raw YUYV frames.
- Switches to caching AVFrame instead of go bytes for use in the processFrames routine.
- Adds YUYV conversion setup and handler.
- Switches to using LibAV MJPEG decoder instead of using the go jpeg decoder.

## Tests
- automated tests:
  - Add unit test for mjpeg decoder ✅ 
  - Add unit test for yuyv to yuv420p converter ✅ 
  - Add unit test for YUYV magic header unpacker ✅ 
- manual tests:
  - yuyv segments playable ✅ 
  - mjpeg segments playable ✅ 
  - yuyv live size change handling ✅ 
  - jpeg live size change handling ✅
