### PR TITLE
[RSDK-9790] - Allow video store to build without a camera dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Additionally, make sure to add your configured data manager service to the `depe
 
 | Attribute       | Sub-Attribute     | Type    | Inclusion | Description                                                                                       |
 |-----------------|-------------------|---------|-----------|---------------------------------------------------------------------------------------------------|
-| `camera`        |                   | string  | optional  | Name of the source camera to read images from.                                                    |
+| `camera`        |                   | string  | optional  | Name of the source camera to read images from. If not provided, video-store will not save video.  |
 | `sync`          |                   | string  | required  | Name of the dependency datamanager service.                                                       |
 | `storage`       |                   | object  | required  |                                                                                                   |
 |                 | `segment_seconds` | integer | optional  | Length in seconds of the individual segment video files.                                          |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Additionally, make sure to add your configured data manager service to the `depe
 
 | Attribute       | Sub-Attribute     | Type    | Inclusion | Description                                                                                       |
 |-----------------|-------------------|---------|-----------|---------------------------------------------------------------------------------------------------|
-| `camera`        |                   | string  | required  | Name of the source camera to read images from.                                                    |
+| `camera`        |                   | string  | optional  | Name of the source camera to read images from.                                                    |
 | `sync`          |                   | string  | required  | Name of the dependency datamanager service.                                                       |
 | `storage`       |                   | object  | required  |                                                                                                   |
 |                 | `segment_seconds` | integer | optional  | Length in seconds of the individual segment video files.                                          |

--- a/cam/cam.go
+++ b/cam/cam.go
@@ -144,9 +144,13 @@ func newvideostore(
 	}
 
 	// Source camera that provides the frames to be processed.
+	// If camera is not available, the component will start
+	// without processing frames.
+	cameraAvailable := true
 	vs.cam, err = camera.FromDependencies(deps, newConf.Camera)
 	if err != nil {
-		return nil, err
+		vs.logger.Error("failed to get camera from dependencies", err)
+		cameraAvailable = false
 	}
 
 	// TODO(seanp): make this configurable
@@ -251,7 +255,9 @@ func newvideostore(
 	}
 
 	// Start workers to process frames and clean up storage.
-	vs.workers = utils.NewBackgroundStoppableWorkers(vs.fetchFrames, vs.processFrames, vs.deleter)
+	if cameraAvailable {
+		vs.workers = utils.NewBackgroundStoppableWorkers(vs.fetchFrames, vs.processFrames, vs.deleter)
+	}
 
 	return vs, nil
 }

--- a/cam/cam.go
+++ b/cam/cam.go
@@ -476,7 +476,9 @@ func (vs *videostore) asyncSave(ctx context.Context, from, to time.Time, path st
 
 // Close closes the video storage camera component.
 func (vs *videostore) Close(_ context.Context) error {
-	vs.workers.Stop()
+	if vs.workers != nil {
+		vs.workers.Stop()
+	}
 	vs.enc.close()
 	vs.seg.close()
 	vs.mh.close()

--- a/cam/cam.go
+++ b/cam/cam.go
@@ -88,7 +88,7 @@ type video struct {
 
 // Config is the configuration for the video storage camera component.
 type Config struct {
-	Camera    string  `json:"camera"`
+	Camera    string  `json:"camera,omitempty"`
 	Sync      string  `json:"sync"`
 	Storage   storage `json:"storage"`
 	Video     video   `json:"video,omitempty"`
@@ -98,9 +98,6 @@ type Config struct {
 
 // Validate validates the configuration for the video storage camera component.
 func (cfg *Config) Validate(path string) ([]string, error) {
-	if cfg.Camera == "" {
-		return nil, utils.NewConfigValidationFieldRequiredError(path, "camera")
-	}
 	if cfg.Storage == (storage{}) {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "storage")
 	}
@@ -114,7 +111,7 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 		return nil, fmt.Errorf("invalid framerate %d, must be greater than 0", cfg.Framerate)
 	}
 
-	return []string{cfg.Camera}, nil
+	return []string{}, nil
 }
 
 func init() {

--- a/cam/cam.go
+++ b/cam/cam.go
@@ -110,7 +110,11 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 	if cfg.Framerate < 0 {
 		return nil, fmt.Errorf("invalid framerate %d, must be greater than 0", cfg.Framerate)
 	}
-
+	// This allows for an implicit camera dependency so we do not need to explicitly
+	// add the camera dependency in the config.
+	if cfg.Camera != "" {
+		return []string{cfg.Camera}, nil
+	}
 	return []string{}, nil
 }
 
@@ -146,7 +150,7 @@ func newvideostore(
 	cameraAvailable := true
 	vs.cam, err = camera.FromDependencies(deps, newConf.Camera)
 	if err != nil {
-		vs.logger.Error("failed to get camera from dependencies", err)
+		vs.logger.Error("failed to get camera from dependencies, video-store will not be storing video", err)
 		cameraAvailable = false
 	}
 

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -430,16 +430,16 @@ func TestModuleConfiguration(t *testing.T) {
 	})
 
 	// no camera specified
-	t.Run("Fails Configuration No Camera", func(t *testing.T) {
+	// we want this to succeed to accept do-command requests
+	t.Run("Succeeds Configuration No Camera", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 		r, err := setupViamServer(timeoutCtx, config2)
 		test.That(t, err, test.ShouldBeNil)
 		defer r.Close(timeoutCtx)
 		cam, err := camera.FromRobot(r, videoStoreComponentName)
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, cam, test.ShouldBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "camera")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, cam, test.ShouldNotBeNil)
 	})
 
 	// no storage specified

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -438,7 +438,7 @@ func TestModuleConfiguration(t *testing.T) {
 							"storage_path": "/tmp"
 						},
 						"video": {
-							"preset": "ultrafast",
+							"preset": "ultrafast"
 						}
 					},
 					"depends_on": [


### PR DESCRIPTION
## Description

Simple PR to allow the module to handle do-command requests even if camera is not available.
- No longer failing to initialize module with missing camera.
- Preventing processing of frames when camera is missing.

## Test

- automated tests:
  - config test succeeds with no camera attr ✅ 
  - implicit camera dep check ✅ 
- manual tests 
  - base case with camera dep:
    - module initializes ✅ 
    - video saves ✅
  - source camera does not exist:
    - module initiializes ✅ 
    - no video saved ✅ 
    - save do-command works ✅ 
    - fetch do-command works ✅ 
- reconfigures:
  - no camera -> adding camera
    - initialization ✅
    - video storage ✅ 
    - save ✅ 
    - fetch ✅ 
  - camera in config -> no camera in config
    - initialization ✅ 
    - video stops being stored ✅ 
    - save ✅ 
    - fetch ✅ 