### PR TITLE
[RSDK-9879] - Make datamanger sync dep implcit

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Additionally, make sure to add your configured data manager service to the `depe
 | Attribute       | Sub-Attribute     | Type    | Inclusion | Description                                                                                       |
 |-----------------|-------------------|---------|-----------|---------------------------------------------------------------------------------------------------|
 | `camera`        |                   | string  | optional  | Name of the source camera to read images from. If not provided, video-store will not save video.  |
-| `sync`          |                   | string  | required  | Name of the dependency datamanager service.                                                       |
+| `sync`          |                   | string  | optional  | Name of the dependency datamanager service.                                                       |
 | `storage`       |                   | object  | required  |                                                                                                   |
 |                 | `segment_seconds` | integer | optional  | Length in seconds of the individual segment video files.                                          |
 |                 | `size_gb`         | integer | required  | Total amount of allocated storage in gigabytes.                                                   |

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -562,20 +562,6 @@ func TestModuleConfiguration(t *testing.T) {
 				"attributes": {}
 			}
 		],
-		"services": [
-			{
-				"name": "data_manager-1",
-				"namespace": "rdk",
-				"type": "data_manager",
-				"attributes": {
-					"additional_sync_paths": [],
-					"capture_disabled": true,
-					"sync_interval_mins": 0.1,
-					"capture_dir": "",
-					"tags": []
-				}
-			}
-		],
 		"modules": [
 			{
 				"type": "local",

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -630,7 +630,7 @@ func TestModuleConfiguration(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 	})
 
-	t.Run("Fails Configuration No DataManager", func(t *testing.T) {
+	t.Run("Specified Sync Without DataManager Service Fails", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 		r, err := setupViamServer(timeoutCtx, config6)

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -477,6 +477,115 @@ func TestModuleConfiguration(t *testing.T) {
 			]
 		}`, fullModuleBinPath)
 
+	// Implicit sync dependency
+	config8 := fmt.Sprintf(`
+	{
+		"components": [
+			{
+				"name": "video-store-1",
+				"namespace": "rdk",
+				"type": "camera",
+				"model": "viam:video:storage",
+				"attributes": {
+					"camera": "fake-cam-1",
+					"sync": "data_manager-1",
+					"storage": {
+						"size_gb": 10,
+						"segment_seconds": 30,
+						"upload_path": "/tmp",
+						"storage_path": "/tmp"
+					},
+					"video": {
+						"preset": "ultrafast"
+					}
+				}
+			},
+			{
+				"name": "fake-cam-1",
+				"namespace": "rdk",
+				"type": "camera",
+				"model": "fake",
+				"attributes": {}
+			}
+		],
+		"services": [
+			{
+				"name": "data_manager-1",
+				"namespace": "rdk",
+				"type": "data_manager",
+				"attributes": {
+					"additional_sync_paths": [],
+					"capture_disabled": true,
+					"sync_interval_mins": 0.1,
+					"capture_dir": "",
+					"tags": []
+				}
+			}
+		],
+		"modules": [
+			{
+				"type": "local",
+				"name": "video-storage",
+				"executable_path": "%s",
+				"log_level": "debug"
+			}
+		]
+	}`, fullModuleBinPath)
+
+	// No sync dependency
+	config9 := fmt.Sprintf(`
+	{
+		"components": [
+			{
+				"name": "video-store-1",
+				"namespace": "rdk",
+				"type": "camera",
+				"model": "viam:video:storage",
+				"attributes": {
+					"camera": "fake-cam-1",
+					"storage": {
+						"size_gb": 10,
+						"segment_seconds": 30,
+						"upload_path": "/tmp",
+						"storage_path": "/tmp"
+					},
+					"video": {
+						"preset": "ultrafast"
+					}
+				}
+			},
+			{
+				"name": "fake-cam-1",
+				"namespace": "rdk",
+				"type": "camera",
+				"model": "fake",
+				"attributes": {}
+			}
+		],
+		"services": [
+			{
+				"name": "data_manager-1",
+				"namespace": "rdk",
+				"type": "data_manager",
+				"attributes": {
+					"additional_sync_paths": [],
+					"capture_disabled": true,
+					"sync_interval_mins": 0.1,
+					"capture_dir": "",
+					"tags": []
+				}
+			}
+		],
+		"modules": [
+			{
+				"type": "local",
+				"name": "video-storage",
+				"executable_path": "%s",
+				"log_level": "debug"
+			}
+		]
+	}`, fullModuleBinPath)
+
 	t.Run("Valid Configuration Successful", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
@@ -551,6 +660,26 @@ func TestModuleConfiguration(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 		r, err := setupViamServer(timeoutCtx, config7)
+		test.That(t, err, test.ShouldBeNil)
+		defer r.Close(timeoutCtx)
+		_, err = camera.FromRobot(r, videoStoreComponentName)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("Implicit Sync Dependency Succeeds", func(t *testing.T) {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		r, err := setupViamServer(timeoutCtx, config8)
+		test.That(t, err, test.ShouldBeNil)
+		defer r.Close(timeoutCtx)
+		_, err = camera.FromRobot(r, videoStoreComponentName)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("No Sync Dependency Succeeds", func(t *testing.T) {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		r, err := setupViamServer(timeoutCtx, config9)
 		test.That(t, err, test.ShouldBeNil)
 		defer r.Close(timeoutCtx)
 		_, err = camera.FromRobot(r, videoStoreComponentName)


### PR DESCRIPTION
## Description
When I first wrote video-store, I did not understand implicit dependencies, so just fixing this now. Also, a user recently wanted to use the module without a sync service so wanted to make that possible.

- Gets rid of hacky explicit datamanager dep check.
- Supports implicit datamanager dep.
- Makes sync attribute optional.

## Tests

- Added automated config tests ✅ 
- Manual tests:
  - Implicit sync dep succeeds ✅ 
  - Missing sync attr succeeds ✅ 
  - Mis-named sync dep fails ✅ 
  - Sync attr with no service fails ✅ 