### PR TITLE
Add h265 embeded video store support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ FFMPEG_OPTS ?= --prefix=$(FFMPEG_BUILD) \
                --enable-static \
                --enable-libx264 \
                --enable-decoder=hevc \
-               --enable-decoder=libx264 \
+               --enable-decoder=h264 \
                --enable-gpl \
                --enable-encoder=libx264 \
                --enable-muxer=segment \

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ FFMPEG_OPTS ?= --prefix=$(FFMPEG_BUILD) \
                --disable-everything \
                --enable-static \
                --enable-libx264 \
+               --enable-decoder=hevc \
                --enable-gpl \
                --enable-encoder=libx264 \
                --enable-muxer=segment \
@@ -34,10 +35,12 @@ FFMPEG_OPTS ?= --prefix=$(FFMPEG_BUILD) \
                --enable-demuxer=mov \
                --enable-demuxer=mp4 \
                --enable-parser=h264 \
+               --enable-parser=hevc \
                --enable-protocol=file \
                --enable-protocol=concat \
                --enable-protocol=crypto \
                --enable-bsf=h264_mp4toannexb \
+               --enable-bsf=hevc_mp4toannexb \
                --enable-decoder=mjpeg
 
 GOFLAGS := -buildvcs=false
@@ -51,9 +54,9 @@ ifeq ($(SOURCE_OS),linux)
 	SUBST = -l:libx264.a
 endif
 ifeq ($(SOURCE_OS),darwin)
-	SUBST = $(HOMEBREW_PREFIX)/Cellar/x264/r3108/lib/libx264.a
+	SUBST = $(HOMEBREW_PREFIX)/Cellar/x264/r3108/lib/libx264.a 
 endif
-CGO_LDFLAGS = $(subst -lx264, $(SUBST),$(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs $(FFMPEG_LIBS))) 
+CGO_LDFLAGS = $(subst -lx264, $(SUBST), $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs $(FFMPEG_LIBS)))
 export PATH := $(PATH):$(shell go env GOPATH)/bin
 
 .PHONY: lint tool-install test clean clean-all clean-ffmpeg module build valgrind

--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,12 @@ OBJS := $(subst $(SRC_DIR), $(BUILD_DIR), $(SRCS:.c=.o))
 PKG_CONFIG_PATH = $(FFMPEG_BUILD)/lib/pkgconfig
 CGO_CFLAGS = $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags $(FFMPEG_LIBS))
 ifeq ($(SOURCE_OS),linux)
-	SUBST = -l:libx264.a
+	SUBST = -l:libx264.a 
 endif
 ifeq ($(SOURCE_OS),darwin)
 	SUBST = $(HOMEBREW_PREFIX)/Cellar/x264/r3108/lib/libx264.a 
 endif
-CGO_LDFLAGS = $(subst -lx264, $(SUBST), $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs $(FFMPEG_LIBS)))
+CGO_LDFLAGS = $(subst -lx264, $(SUBST),$(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs $(FFMPEG_LIBS))) 
 export PATH := $(PATH):$(shell go env GOPATH)/bin
 
 .PHONY: lint tool-install test clean clean-all clean-ffmpeg module build valgrind

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ FFMPEG_OPTS ?= --prefix=$(FFMPEG_BUILD) \
                --enable-static \
                --enable-libx264 \
                --enable-decoder=hevc \
+               --enable-decoder=libx264 \
                --enable-gpl \
                --enable-encoder=libx264 \
                --enable-muxer=segment \

--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,10 @@ OBJS := $(subst $(SRC_DIR), $(BUILD_DIR), $(SRCS:.c=.o))
 PKG_CONFIG_PATH = $(FFMPEG_BUILD)/lib/pkgconfig
 CGO_CFLAGS = $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags $(FFMPEG_LIBS))
 ifeq ($(SOURCE_OS),linux)
-	SUBST = -l:libx264.a 
+	SUBST = -l:libx264.a
 endif
 ifeq ($(SOURCE_OS),darwin)
-	SUBST = $(HOMEBREW_PREFIX)/Cellar/x264/r3108/lib/libx264.a 
+	SUBST = $(HOMEBREW_PREFIX)/Cellar/x264/r3108/lib/libx264.a
 endif
 CGO_LDFLAGS = $(subst -lx264, $(SUBST),$(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs $(FFMPEG_LIBS))) 
 export PATH := $(PATH):$(shell go env GOPATH)/bin

--- a/cmd/concat/cmd.go
+++ b/cmd/concat/cmd.go
@@ -36,7 +36,7 @@ func main() {
 	if err != nil {
 		logger.Fatal(err.Error())
 	}
-	vs, err := videostore.NewH264RTPVideoStore(ctx, config, logger)
+	vs, err := videostore.NewRTPVideoStore(config, logger)
 	if err != nil {
 		logger.Fatal(err.Error())
 	}

--- a/cmd/raw-segmenter-c/main.c
+++ b/cmd/raw-segmenter-c/main.c
@@ -5,15 +5,17 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <libavcodec/avcodec.h>
 
 int main(int argc, char *argv[]) {
   if (argc != 2) {
     printf("usage: %s <sqlite.db>\n", argv[0]);
     printf("TABLE should have the following schema:\n");
-    printf("CREATE TABLE extradata(id INTEGER NOT NULL PRIMARY KEY, data "
-           "BLOB);\n");
+
+    printf("CREATE TABLE extradata(id INTEGER NOT NULL PRIMARY KEY, isH264 "
+           "BOOLEAN, width INTEGER, height INTEGER);\n");
     printf("CREATE TABLE packet(id INTEGER NOT NULL PRIMARY KEY, pts "
-           "INTEGER,isIDR BOOLEAN, data BLOB);\n");
+           "INTEGER,dts INTEGER,isIDR BOOLEAN, data BLOB);\n");
 
     return 1;
   }
@@ -32,9 +34,10 @@ int main(int argc, char *argv[]) {
   sqlite3_stmt *statement;
   /* Compile the SELECT statement into a virtual machine. */
   printf("Performing query...\n");
-  if ((rc = sqlite3_prepare_v2(db, "SELECT data FROM extradata;", -1,
-                               &statement, 0))) {
-    printf("sqlite3_prepare failed: %d\n", rc);
+  if ((rc = sqlite3_prepare_v2(db,
+                               "SELECT isH264, width, height FROM extradata;",
+                               -1, &statement, 0))) {
+    printf("sqlite3_prepare failed on extradata: %d\n", rc);
     return rc;
   }
 
@@ -43,11 +46,19 @@ int main(int argc, char *argv[]) {
     printf("sqlite3_step failed: %d\n", rc);
     return rc;
   }
+  int isH264 = sqlite3_column_int(statement, 0);
+  int width = sqlite3_column_int(statement, 1);
+  int height = sqlite3_column_int(statement, 2);
 
-  ret = video_store_raw_seg_init_h265(&rs, 30, "./mp4s/%Y-%m-%d_%H-%M-%S.mp4",
-                                      2960, 1668);
+  if (isH264) {
+    ret = video_store_raw_seg_init_h264(
+        &rs, 30, "./mp4s/h264_%Y-%m-%d_%H-%M-%S.mp4", width, height);
+  } else {
+    ret = video_store_raw_seg_init_h265(
+        &rs, 30, "./mp4s/h265_%Y-%m-%d_%H-%M-%S.mp4", width, height);
+  }
   if (ret != VIDEO_STORE_RAW_SEG_RESP_OK) {
-    printf("video_store_raw_seg_init_h265 failed: %d\n", ret);
+    printf("video_store_raw_seg_init failed: %d\n", ret);
     rc = sqlite3_finalize(statement);
     if (rc != SQLITE_OK) {
       printf("sqlite3_finalize failed: %d\n", rc);
@@ -64,7 +75,8 @@ int main(int argc, char *argv[]) {
     return rc;
   }
 
-  if ((rc = sqlite3_prepare_v2(db, "SELECT id, pts, isIDR, data FROM packet;",
+  if ((rc = sqlite3_prepare_v2(db,
+                               "SELECT id, pts, dts, isIDR, data FROM packet;",
                                -1, &statement, 0))) {
     printf("sqlite3_prepare failed: %d\n", rc);
     return rc;
@@ -79,11 +91,11 @@ int main(int argc, char *argv[]) {
       break;
     }
     pts = sqlite3_column_int64(statement, 1);
-    dts = pts;
-    isIDR = sqlite3_column_int(statement, 2);
+    dts = sqlite3_column_int64(statement, 2);
+    isIDR = sqlite3_column_int(statement, 3);
     ret = video_store_raw_seg_write_packet(
-        rs, sqlite3_column_blob(statement, 3),
-        (size_t)sqlite3_column_bytes(statement, 3), pts, dts, isIDR);
+        rs, sqlite3_column_blob(statement, 4),
+        (size_t)sqlite3_column_bytes(statement, 4), pts, dts, isIDR);
     if (ret != VIDEO_STORE_RAW_SEG_RESP_OK) {
       failed = 1;
       printf("video_store_raw_seg_write_packet failed: %d\n", ret);

--- a/cmd/raw-segmenter-c/main.c
+++ b/cmd/raw-segmenter-c/main.c
@@ -5,7 +5,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <libavcodec/avcodec.h>
 
 int main(int argc, char *argv[]) {
   if (argc != 2) {

--- a/cmd/raw-segmenter-c/main.c
+++ b/cmd/raw-segmenter-c/main.c
@@ -1,4 +1,5 @@
 #include "../../videostore/rawsegmenter.h"
+#include "libavutil/log.h"
 #include <sqlite3.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -17,6 +18,7 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
+  av_log_set_level(AV_LOG_DEBUG);
   sqlite3 *db = NULL;
   int rc = 0;
 
@@ -25,7 +27,7 @@ int main(int argc, char *argv[]) {
     return 1;
   };
 
-  struct raw_seg_h264 *rs;
+  struct raw_seg *rs;
   int ret = 0;
   sqlite3_stmt *statement;
   /* Compile the SELECT statement into a virtual machine. */
@@ -42,12 +44,10 @@ int main(int argc, char *argv[]) {
     return rc;
   }
 
-  ret = video_store_raw_seg_init_h264(
-      &rs, 30, "./mp4s/%Y-%m-%d_%H-%M-%S.mp4",
-      sqlite3_column_blob(statement, 0),
-      (size_t)sqlite3_column_bytes(statement, 0), 2560, 1440);
+  ret = video_store_raw_seg_init_h265(&rs, 30, "./mp4s/%Y-%m-%d_%H-%M-%S.mp4",
+                                      2960, 1668);
   if (ret != VIDEO_STORE_RAW_SEG_RESP_OK) {
-    printf("video_store_raw_seg_init_h264 failed: %d\n", ret);
+    printf("video_store_raw_seg_init_h265 failed: %d\n", ret);
     rc = sqlite3_finalize(statement);
     if (rc != SQLITE_OK) {
       printf("sqlite3_finalize failed: %d\n", rc);
@@ -70,6 +70,7 @@ int main(int argc, char *argv[]) {
     return rc;
   }
   int64_t pts = 0;
+  int64_t dts = 0;
   int isIDR = 0;
   int failed = 0;
   while (1) {
@@ -78,13 +79,14 @@ int main(int argc, char *argv[]) {
       break;
     }
     pts = sqlite3_column_int64(statement, 1);
+    dts = pts;
     isIDR = sqlite3_column_int(statement, 2);
-    ret = video_store_raw_seg_write_h264_packet(
+    ret = video_store_raw_seg_write_packet(
         rs, sqlite3_column_blob(statement, 3),
-        (size_t)sqlite3_column_bytes(statement, 3), pts, isIDR);
+        (size_t)sqlite3_column_bytes(statement, 3), pts, dts, isIDR);
     if (ret != VIDEO_STORE_RAW_SEG_RESP_OK) {
       failed = 1;
-      printf("video_store_raw_seg_write_h264_packet failed: %d\n", ret);
+      printf("video_store_raw_seg_write_packet failed: %d\n", ret);
       break;
     }
   }
@@ -107,7 +109,9 @@ int main(int argc, char *argv[]) {
   }
 
   if (failed) {
+    printf("failed: %d\n", failed);
     return 1;
   }
+  printf("succeeded\n");
   return 0;
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ toolchain go1.23.1
 require (
 	github.com/AlekSi/gocov-xml v1.0.0
 	github.com/axw/gocov v1.1.0
-	github.com/bluenviron/mediacommon v1.9.2
 	github.com/edaniels/golinters v0.0.5-0.20220906153528-641155550742
 	github.com/fullstorydev/grpcurl v1.8.6
 	github.com/golangci/golangci-lint v1.61.0
@@ -60,6 +59,7 @@ require (
 	github.com/blackjack/webcam v0.6.1 // indirect
 	github.com/blizzy78/varnamelen v0.8.0 // indirect
 	github.com/bluenviron/gortsplib/v4 v4.8.0 // indirect
+	github.com/bluenviron/mediacommon v1.9.2 // indirect
 	github.com/bombsimon/wsl/v4 v4.4.1 // indirect
 	github.com/breml/bidichk v0.2.7 // indirect
 	github.com/breml/errchkjson v0.3.6 // indirect

--- a/model/camera/camera.go
+++ b/model/camera/camera.go
@@ -155,8 +155,9 @@ func (c *component) Properties(_ context.Context) (camera.Properties, error) {
 }
 
 // Close closes the video storage camera component.
-func (c *component) Close(ctx context.Context) error {
-	return c.videostore.Close(ctx)
+func (c *component) Close(_ context.Context) error {
+	c.videostore.Close()
+	return nil
 }
 
 // Unimplemented methods for the video storage camera component.

--- a/videostore/concat.c
+++ b/videostore/concat.c
@@ -132,7 +132,7 @@ int video_store_concat(const char *concat_filepath, const char *output_path) {
     if (packet->dts <= prevDts) {
       av_log(NULL, AV_LOG_DEBUG,
              "video_store_concat skipping non monotonically increaseing dts: "
-             "%lld, prevDts: %lld\n",
+             "%ld, prevDts: %ld\n",
              packet->dts, prevDts);
       av_packet_unref(packet);
       continue;

--- a/videostore/concat.c
+++ b/videostore/concat.c
@@ -15,7 +15,8 @@ int video_store_concat(const char *concat_filepath, const char *output_path) {
   int outputPathOpened = 0;
   const AVInputFormat *inputFormat = av_find_input_format("concat");
   if (inputFormat == NULL) {
-    av_log(NULL, AV_LOG_ERROR, "video_store_concat failed to find input format\n");
+    av_log(NULL, AV_LOG_ERROR,
+           "video_store_concat failed to find input format\n");
     goto cleanup;
   }
 
@@ -74,8 +75,6 @@ int video_store_concat(const char *concat_filepath, const char *output_path) {
              i, av_err2str(ret));
       goto cleanup;
     }
-    // Let ffmpeg handle the codec tag for us.
-    outStream->codecpar->codec_tag = 0;
   }
 
   ret = avio_open(&outputCtx->pb, output_path, AVIO_FLAG_WRITE);

--- a/videostore/concat.c
+++ b/videostore/concat.c
@@ -112,6 +112,10 @@ int video_store_concat(const char *concat_filepath, const char *output_path) {
       goto cleanup;
     }
 
+    if ((packet->flags & AV_PKT_FLAG_DISCARD) == AV_PKT_FLAG_DISCARD) {
+      av_packet_unref(packet);
+      continue;
+    }
     inStream = inputCtx->streams[packet->stream_index];
     outStream = outputCtx->streams[packet->stream_index];
     packet->pts =
@@ -124,10 +128,6 @@ int video_store_concat(const char *concat_filepath, const char *output_path) {
         packet->duration, inStream->time_base, outStream->time_base,
         AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX);
     packet->pos = -1;
-    if ((packet->flags & AV_PKT_FLAG_DISCARD) == AV_PKT_FLAG_DISCARD) {
-      av_packet_unref(packet);
-      continue;
-    }
 
     if (packet->dts <= prevDts) {
       av_log(NULL, AV_LOG_DEBUG,

--- a/videostore/config.go
+++ b/videostore/config.go
@@ -20,6 +20,8 @@ const (
 	SourceTypeFrame
 	// SourceTypeH264RTPPacket is a video store that creates a video from rtp packets.
 	SourceTypeH264RTPPacket
+	// SourceTypeH265RTPPacket is a video store that creates a video from rtp packets.
+	SourceTypeH265RTPPacket
 )
 
 func (t SourceType) String() string {
@@ -30,6 +32,8 @@ func (t SourceType) String() string {
 		return "VideoStoreTypeFrame"
 	case SourceTypeH264RTPPacket:
 		return "SourceTypeH264RTPPacket"
+	case SourceTypeH265RTPPacket:
+		return "SourceTypeH265RTPPacket"
 	default:
 		return "VideoStoreTypeUnknown"
 	}

--- a/videostore/rawsegmenter.c
+++ b/videostore/rawsegmenter.c
@@ -8,29 +8,19 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-int video_store_raw_seg_init_h264(struct raw_seg_h264 **ppRS, // OUT
-                                  const int segmentSeconds,   // IN
-                                  const char *outputPattern,  // IN
-                                  const char *extradata,      // IN
-                                  const size_t extradataSize, // IN
-                                  const int width,            // IN
-                                  const int height            // IN
+int video_store_raw_seg_init(struct raw_seg **ppRS,     // OUT
+                             const int segmentSeconds,  // IN
+                             const char *outputPattern, // IN
+                             const int width,           // IN
+                             const int height,          // IN
+                             const AVCodec *codec       // IN
 ) {
-  struct raw_seg_h264 *rs =
-      (struct raw_seg_h264 *)malloc(sizeof(struct raw_seg_h264));
+  struct raw_seg *rs = (struct raw_seg *)malloc(sizeof(struct raw_seg));
   if (rs == NULL) {
     av_log(NULL, AV_LOG_ERROR,
-           "video_store_raw_seg_init_h264 failed allocate a raw_seg_h264");
+           "video_store_raw_seg_init failed allocate a raw_seg_h264\n");
     return VIDEO_STORE_RAW_SEG_RESP_ERROR;
   }
-
-  const struct AVCodec *codec = avcodec_find_encoder(AV_CODEC_ID_H264);
-  if (codec == NULL) {
-    av_log(NULL, AV_LOG_ERROR,
-           "video_store_raw_seg_init_h264 failed to find codec");
-    return VIDEO_STORE_RAW_SEG_RESP_ERROR;
-  }
-
   AVFormatContext *fmtCtx = NULL;
   AVStream *stream = NULL;
   AVCodecContext *codecCtx = NULL;
@@ -38,17 +28,16 @@ int video_store_raw_seg_init_h264(struct raw_seg_h264 **ppRS, // OUT
   int ret = 0;
   ret = avformat_alloc_output_context2(&fmtCtx, NULL, "segment", outputPattern);
   if (ret < 0) {
-    av_log(
-        NULL, AV_LOG_ERROR,
-        "video_store_raw_seg_init_h264 failed to allocate format context: %s\n",
-        av_err2str(ret));
+    av_log(NULL, AV_LOG_ERROR,
+           "video_store_raw_seg_init failed to allocate format context: %s\n",
+           av_err2str(ret));
     goto cleanup;
   }
   /* // Create new stream for the output context. */
   stream = avformat_new_stream(fmtCtx, NULL);
   if (stream == NULL) {
     av_log(NULL, AV_LOG_ERROR,
-           "video_store_raw_seg_init_h264 failed to allocate stream");
+           "video_store_raw_seg_init failed to allocate stream\n");
     ret = VIDEO_STORE_RAW_SEG_RESP_ERROR;
     goto cleanup;
   }
@@ -58,33 +47,25 @@ int video_store_raw_seg_init_h264(struct raw_seg_h264 **ppRS, // OUT
   codecCtx = avcodec_alloc_context3(codec);
   if (codecCtx == NULL) {
     av_log(NULL, AV_LOG_ERROR,
-           "video_store_raw_seg_init_h264 failed to allocate codec context");
+           "video_store_raw_seg_init failed to allocate codec context\n");
     ret = VIDEO_STORE_RAW_SEG_RESP_ERROR;
     goto cleanup;
   }
 
   codecCtx->width = width;
   codecCtx->height = height;
-  codecCtx->extradata = av_malloc(extradataSize + AV_INPUT_BUFFER_PADDING_SIZE);
-  if (codecCtx->extradata == NULL) {
-    av_log(NULL, AV_LOG_ERROR,
-           "video_store_raw_seg_init_h264 failed to allocate extradata");
-    ret = VIDEO_STORE_RAW_SEG_RESP_ERROR;
-    goto cleanup;
-  }
-  codecCtx->extradata_size = (int)extradataSize;
 
-  // memcpy can't fail
-  memcpy(codecCtx->extradata, extradata, extradataSize);
-  /* // Copy the codec parameters from the input stream to the output
-   * stream. This is equivalent */
-  /* // to -c:v copy in ffmpeg cli. This is needed to make sure we do not
-   * re-encode the stream. */
   ret = avcodec_parameters_from_context(stream->codecpar, codecCtx);
   if (ret < 0) {
     av_log(NULL, AV_LOG_ERROR,
-           "video_store_raw_seg_init_h264 failed to copy codec parameters");
+           "video_store_raw_seg_init failed to copy codec parameters\n");
     goto cleanup;
+  }
+  if (codec->id == AV_CODEC_ID_H265) {
+    // this is needed  to make h265 videos playable on apple devices
+    // https://trac.ffmpeg.org/wiki/Encode/H.265#FinalCutandApplestuffcompatibility
+    // https://stackoverflow.com/questions/50565912/h265-codec-changes-from-hvc1-to-hev1
+    stream->codecpar->codec_tag = MKTAG('h', 'v', 'c', '1');
   }
 
   char stackSegmentSecondsStr[30];
@@ -93,28 +74,28 @@ int video_store_raw_seg_init_h264(struct raw_seg_h264 **ppRS, // OUT
   ret = av_dict_set(&opts, "segment_time", stackSegmentSecondsStr, 0);
   if (ret < 0) {
     av_log(NULL, AV_LOG_ERROR,
-           "video_store_raw_seg_init_h264 failed to set segment_time");
+           "video_store_raw_seg_init failed to set segment_time\n");
     goto cleanup;
   }
 
   ret = av_dict_set(&opts, "segment_format", "mp4", 0);
   if (ret < 0) {
     av_log(NULL, AV_LOG_ERROR,
-           "video_store_raw_seg_init_h264 failed to set segment_format");
+           "video_store_raw_seg_init failed to set segment_format\n");
     goto cleanup;
   }
 
   ret = av_dict_set(&opts, "reset_timestamps", "1", 0);
   if (ret < 0) {
     av_log(NULL, AV_LOG_ERROR,
-           "video_store_raw_seg_init_h264 failed to set reset_timestamps");
+           "video_store_raw_seg_init failed to set reset_timestamps\n");
     goto cleanup;
   }
 
   ret = av_dict_set(&opts, "strftime", "1", 0);
   if (ret < 0) {
     av_log(NULL, AV_LOG_ERROR,
-           "video_store_raw_seg_init_h264 failed to set strftime");
+           "video_store_raw_seg_init failed to set strftime\n");
     goto cleanup;
   }
 
@@ -122,7 +103,7 @@ int video_store_raw_seg_init_h264(struct raw_seg_h264 **ppRS, // OUT
   ret = avformat_write_header(fmtCtx, &opts);
   if (ret < 0) {
     av_log(NULL, AV_LOG_ERROR,
-           "video_store_raw_seg_init_h264 failed to write header");
+           "video_store_raw_seg_init failed to write header\n");
     goto cleanup;
   }
 
@@ -147,37 +128,69 @@ cleanup:
   return ret;
 }
 
-int video_store_raw_seg_write_h264_packet(struct raw_seg_h264 *rs,  // IN
-                                          const char *payload,      // IN
-                                          const size_t payloadSize, // IN
-                                          const int64_t pts,        // IN
-                                          const int isIdr           // IN
+int video_store_raw_seg_init_h264(struct raw_seg **ppRS,     // OUT
+                                  const int segmentSeconds,  // IN
+                                  const char *outputPattern, // IN
+                                  const int width,           // IN
+                                  const int height           // IN
+) {
+  const struct AVCodec *codec = avcodec_find_decoder(AV_CODEC_ID_H264);
+  if (codec == NULL) {
+    av_log(NULL, AV_LOG_ERROR,
+           "video_store_raw_seg_init_h264 failed to find codec\n");
+    return VIDEO_STORE_RAW_SEG_RESP_ERROR;
+  }
+  return video_store_raw_seg_init(ppRS, segmentSeconds, outputPattern, width,
+                                  height, codec);
+}
+
+int video_store_raw_seg_init_h265(struct raw_seg **ppRS,     // OUT
+                                  const int segmentSeconds,  // IN
+                                  const char *outputPattern, // IN
+                                  const int width,           // IN
+                                  const int height           // IN
+) {
+  const struct AVCodec *codec = avcodec_find_decoder(AV_CODEC_ID_H265);
+  if (codec == NULL) {
+    av_log(NULL, AV_LOG_ERROR,
+           "video_store_raw_seg_init_h265 failed to find codec\n");
+    return VIDEO_STORE_RAW_SEG_RESP_ERROR;
+  }
+  return video_store_raw_seg_init(ppRS, segmentSeconds, outputPattern, width,
+                                  height, codec);
+}
+
+int video_store_raw_seg_write_packet(struct raw_seg *rs,       // IN
+                                     const char *payload,      // IN
+                                     const size_t payloadSize, // IN
+                                     const int64_t pts,        // IN
+                                     const int64_t dts,        // IN
+                                     const int isIdr           // IN
 ) {
   int ret = VIDEO_STORE_RAW_SEG_RESP_ERROR;
   if (payloadSize == 0) {
-    av_log(
-        NULL, AV_LOG_ERROR,
-        "video_store_raw_seg_write_h264_packet called with empty payload size");
+    av_log(NULL, AV_LOG_ERROR,
+           "video_store_raw_seg_write_packet called with empty payload size\n");
     return VIDEO_STORE_RAW_SEG_RESP_ERROR;
   }
 
   if (payload == NULL) {
     av_log(NULL, AV_LOG_ERROR,
-           "video_store_raw_seg_write_h264_packet called with null payload");
+           "video_store_raw_seg_write_packet called with null payload\n");
     return VIDEO_STORE_RAW_SEG_RESP_ERROR;
   }
 
   if (rs->outCtx == NULL) {
     av_log(NULL, AV_LOG_ERROR,
-           "video_store_raw_seg_write_h264_packet called before "
-           "video_store_raw_seg_write_h264_packet");
+           "video_store_raw_seg_write_packet called before "
+           "video_store_raw_seg_write_packet\n");
     return VIDEO_STORE_RAW_SEG_RESP_ERROR;
   }
 
   AVPacket *pkt = av_packet_alloc();
   if (pkt == NULL) {
     av_log(NULL, AV_LOG_ERROR,
-           "video_store_raw_seg_write_h264_packet failed to allocate AVPacket");
+           "video_store_raw_seg_write_packet failed to allocate AVPacket\n");
     ret = VIDEO_STORE_RAW_SEG_RESP_ERROR;
     goto cleanup;
   }
@@ -187,8 +200,8 @@ int video_store_raw_seg_write_h264_packet(struct raw_seg_h264 *rs,  // IN
   ret = av_packet_from_data(pkt, data, (int)payloadSize);
   if (ret != 0) {
     av_log(NULL, AV_LOG_ERROR,
-           "video_store_raw_seg_write_h264_packet failed to create new "
-           "AVPacket from data");
+           "video_store_raw_seg_write_packet failed to create new "
+           "AVPacket from data\n");
     // if av_packet_from_data returned an error then data is not owned by the
     // packet and we need to free it outselves
     av_free(data);
@@ -197,7 +210,7 @@ int video_store_raw_seg_write_h264_packet(struct raw_seg_h264 *rs,  // IN
 
   pkt->size = (int)payloadSize;
   pkt->pts = pts;
-  pkt->dts = pts;
+  pkt->dts = dts;
   /* // Set the keyframe flag if this is an IDR frame. This is needed to
    * make sure the */
   /* // muxer knows it is a keyframe and is safe to start a new segment. */
@@ -207,7 +220,7 @@ int video_store_raw_seg_write_h264_packet(struct raw_seg_h264 *rs,  // IN
   // Write the packet to the output file.
   if ((ret = av_interleaved_write_frame(rs->outCtx, pkt))) {
     av_log(NULL, AV_LOG_ERROR,
-           "video_store_raw_seg_write_h264_packet failed to write frame");
+           "video_store_raw_seg_write_packet failed to write frame\n");
     goto cleanup;
   }
 
@@ -220,23 +233,23 @@ cleanup:
   return ret;
 }
 
-int video_store_raw_seg_close(struct raw_seg_h264 **ppRS // OUT
+int video_store_raw_seg_close(struct raw_seg **ppRS // OUT
 ) {
   if (ppRS == NULL) {
     av_log(NULL, AV_LOG_ERROR,
-           "video_store_raw_seg_close called with null raw_seg_h264 **ppRS");
+           "video_store_raw_seg_close called with null raw_seg_h264 **ppRS\n");
     return VIDEO_STORE_RAW_SEG_RESP_ERROR;
   }
 
   if (*ppRS == NULL) {
     av_log(NULL, AV_LOG_ERROR,
-           "video_store_raw_seg_close called with null raw_seg_h264 *ppRS");
+           "video_store_raw_seg_close called with null raw_seg_h264 *ppRS\n");
     return VIDEO_STORE_RAW_SEG_RESP_ERROR;
   }
   int ret = av_write_trailer((*ppRS)->outCtx);
   if (ret < 0) {
     av_log(NULL, AV_LOG_ERROR,
-           "video_store_raw_seg_close called failed to write trailer");
+           "video_store_raw_seg_close called failed to write trailer\n");
     return ret;
   }
   avformat_free_context((*ppRS)->outCtx);

--- a/videostore/rawsegmenter.go
+++ b/videostore/rawsegmenter.go
@@ -60,10 +60,6 @@ func newRawSegmenter(
 }
 
 func (rs *rawSegmenter) init(width, height int) error {
-	// if len(extradata) == 0 {
-	// 	return errors.New("extradata should not be empty")
-	// }
-
 	if width <= 0 || height <= 0 {
 		return errors.New("both width and height should be greater than zero")
 	}
@@ -83,8 +79,6 @@ func (rs *rawSegmenter) init(width, height int) error {
 	// that specifies the output file name. The pattern is set to the current time.
 	outputPatternCStr := C.CString(rs.storagePath + "/" + outputPattern)
 	defer C.free(unsafe.Pointer(outputPatternCStr))
-	// extradataCStr := C.CBytes(extradata)
-	// defer C.free(extradataCStr)
 	var ret C.int
 	switch rs.typ {
 	case SourceTypeH264RTPPacket:
@@ -92,8 +86,6 @@ func (rs *rawSegmenter) init(width, height int) error {
 			&cRS,
 			C.int(rs.segmentSeconds),
 			outputPatternCStr,
-			// (*C.char)(extradataCStr),
-			// C.size_t(len(extradata)),
 			C.int(width),
 			C.int(height))
 	case SourceTypeH265RTPPacket:
@@ -101,8 +93,6 @@ func (rs *rawSegmenter) init(width, height int) error {
 			&cRS,
 			C.int(rs.segmentSeconds),
 			outputPatternCStr,
-			// (*C.char)(extradataCStr),
-			// C.size_t(len(extradata)),
 			C.int(width),
 			C.int(height))
 	case SourceTypeFrame:

--- a/videostore/rawsegmenter.go
+++ b/videostore/rawsegmenter.go
@@ -8,15 +8,16 @@ import "C"
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"sync"
 	"unsafe"
 
-	"github.com/bluenviron/mediacommon/pkg/codecs/h264"
 	"go.viam.com/rdk/logging"
 )
 
 type rawSegmenter struct {
+	typ            SourceType
 	logger         logging.Logger
 	storagePath    string
 	segmentSeconds int
@@ -24,16 +25,28 @@ type rawSegmenter struct {
 	initialized    bool
 	closed         bool
 	maxStorageSize int64
-	cRawSeg        *C.raw_seg_h264
+	cRawSeg        *C.raw_seg
 }
 
 func newRawSegmenter(
 	logger logging.Logger,
+	typ SourceType,
 	storageSize int,
 	storagePath string,
 	segmentSeconds int,
 ) (*rawSegmenter, error) {
+	logger.Info("newRawSegmenter start")
+	switch typ {
+	case SourceTypeH264RTPPacket, SourceTypeH265RTPPacket:
+	case SourceTypeFrame:
+		logger.Errorf("newRawSegmenter got INVALID type %s", typ)
+		return nil, fmt.Errorf("unsupported SourceType %d: %s", typ, typ)
+	default:
+		logger.Errorf("newRawSegmenter got INVALID type %s", typ)
+		return nil, fmt.Errorf("unsupported SourceType %d: %s", typ, typ)
+	}
 	s := &rawSegmenter{
+		typ:            typ,
 		logger:         logger,
 		storagePath:    storagePath,
 		segmentSeconds: segmentSeconds,
@@ -46,15 +59,15 @@ func newRawSegmenter(
 	return s, nil
 }
 
-func (rs *rawSegmenter) initH264(sps, pps []byte) error {
-	if len(sps) == 0 || len(pps) == 0 {
-		return errors.New("both sps & pps must not be empty")
+func (rs *rawSegmenter) init(width, height int) error {
+	// if len(extradata) == 0 {
+	// 	return errors.New("extradata should not be empty")
+	// }
+
+	if width <= 0 || height <= 0 {
+		return errors.New("both width and height should be greater than zero")
 	}
 
-	var hsps h264.SPS
-	if err := hsps.Unmarshal(sps); err != nil {
-		return err
-	}
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
 	if rs.initialized {
@@ -64,30 +77,40 @@ func (rs *rawSegmenter) initH264(sps, pps []byte) error {
 	if rs.closed {
 		return errors.New("*rawSegmenter init called after close")
 	}
-
-	// Set up the extradata for the codec context. This allows the muxer to know how to
-	// decode the stream without having to read the SPS/PPS from the stream.
-	extradata, err := buildAVCExtradata(sps, pps)
-	if err != nil {
-		rs.logger.Error("failed to build extradata: ", err)
-		return err
-	}
-	var cRS *C.raw_seg_h264
+	var cRS *C.raw_seg
 	// Allocate output context for segmenter. The "segment" format is a special format
 	// that allows for segmenting output files. The output pattern is a strftime pattern
 	// that specifies the output file name. The pattern is set to the current time.
 	outputPatternCStr := C.CString(rs.storagePath + "/" + outputPattern)
 	defer C.free(unsafe.Pointer(outputPatternCStr))
-	extradataCStr := C.CBytes(extradata)
-	defer C.free(extradataCStr)
-	ret := C.video_store_raw_seg_init_h264(
-		&cRS,
-		C.int(rs.segmentSeconds),
-		outputPatternCStr,
-		(*C.char)(extradataCStr),
-		C.size_t(len(extradata)),
-		C.int(hsps.Width()),
-		C.int(hsps.Height()))
+	// extradataCStr := C.CBytes(extradata)
+	// defer C.free(extradataCStr)
+	var ret C.int
+	switch rs.typ {
+	case SourceTypeH264RTPPacket:
+		ret = C.video_store_raw_seg_init_h264(
+			&cRS,
+			C.int(rs.segmentSeconds),
+			outputPatternCStr,
+			// (*C.char)(extradataCStr),
+			// C.size_t(len(extradata)),
+			C.int(width),
+			C.int(height))
+	case SourceTypeH265RTPPacket:
+		ret = C.video_store_raw_seg_init_h265(
+			&cRS,
+			C.int(rs.segmentSeconds),
+			outputPatternCStr,
+			// (*C.char)(extradataCStr),
+			// C.size_t(len(extradata)),
+			C.int(width),
+			C.int(height))
+	case SourceTypeFrame:
+		fallthrough
+	default:
+		return errors.New("invalid source type")
+	}
+
 	if ret != C.VIDEO_STORE_RAW_SEG_RESP_OK {
 		return errors.New("failed to initialize raw segmenter")
 	}
@@ -97,11 +120,15 @@ func (rs *rawSegmenter) initH264(sps, pps []byte) error {
 	return nil
 }
 
-func (rs *rawSegmenter) writePacket(payload []byte, pts int64, isIDR bool) error {
+func (rs *rawSegmenter) writePacket(payload []byte, pts, dts int64, isIDR bool) error {
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
 	if !rs.initialized {
-		return errors.New("writePacket called before initH264")
+		return errors.New("writePacket called before init")
+	}
+
+	if rs.closed {
+		return errors.New("writePacket called after close")
 	}
 
 	if len(payload) == 0 {
@@ -115,11 +142,12 @@ func (rs *rawSegmenter) writePacket(payload []byte, pts int64, isIDR bool) error
 	if isIDR {
 		idr = C.int(1)
 	}
-	ret := C.video_store_raw_seg_write_h264_packet(
+	ret := C.video_store_raw_seg_write_packet(
 		rs.cRawSeg,
 		(*C.char)(payloadC),
 		C.size_t(len(payload)),
 		C.int64_t(pts),
+		C.int64_t(dts),
 		idr)
 	if ret != C.VIDEO_STORE_RAW_SEG_RESP_OK {
 		return errors.New("failed to write packet")
@@ -132,71 +160,17 @@ func (rs *rawSegmenter) writePacket(payload []byte, pts int64, isIDR bool) error
 func (rs *rawSegmenter) close() {
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
+	if !rs.initialized {
+		return
+	}
 	if rs.closed {
 		return
 	}
 	ret := C.video_store_raw_seg_close(&rs.cRawSeg)
 	if ret != C.VIDEO_STORE_RAW_SEG_RESP_OK {
-		rs.logger.Error("failed to close raw segmeneter")
+		rs.logger.Errorf("failed to close raw segmeneter: %d", ret)
 	}
-}
-
-/*
-	aligned(8) class AVCDecoderConfigurationRecord {
-		   unsigned int(8) configurationVersion = 1;
-		   unsigned int(8) AVCProfileIndication;
-		   unsigned int(8) profile_compatibility;
-		   unsigned int(8) AVCLevelIndication;
-		   bit(6) reserved = ‘111111’b;
-		   unsigned int(2) lengthSizeMinusOne;
-		   bit(3) reserved = ‘111’b;
-		   unsigned int(5) numOfSequenceParameterSets;
-		   for (i=0; i< numOfSequenceParameterSets;  i++) {
-		      unsigned int(16) sequenceParameterSetLength ;
-		  bit(8*sequenceParameterSetLength) sequenceParameterSetNALUnit;
-		 }
-		   unsigned int(8) numOfPictureParameterSets;
-		   for (i=0; i< numOfPictureParameterSets;  i++) {
-		  unsigned int(16) pictureParameterSetLength;
-		  bit(8*pictureParameterSetLength) pictureParameterSetNALUnit;
-		 }
-		}
-*/
-// buildAVCExtradata builds the AVCDecoderConfigurationRecord extradata from the SPS and PPS data.
-// The SPS and PPS data are expected to be packed into the format listed above.
-func buildAVCExtradata(sps, pps []byte) ([]byte, error) {
-	if len(sps) < 4 || len(pps) < 1 {
-		return nil, errors.New("invalid SPS/PPS data")
-	}
-	extradata := []byte{}
-	// configurationVersion
-	extradata = append(extradata, 1)
-	// AVCProfileIndication, profile_compatibility, AVCLevelIndication (from SPS)
-	extradata = append(extradata, sps[1], sps[2], sps[3])
-	// 6 bits reserved (111111) + 2 bits lengthSizeMinusOne (3 for 4 bytes)
-	//nolint:mnd
-	extradata = append(extradata, 0xFF)
-	// 3 bits reserved (111) + 5 bits numOfSequenceParameterSets (usually 1)
-	//nolint:mnd
-	extradata = append(extradata, 0xE1)
-	// SPS length (2 bytes big-endian)
-	spsLen := uint16(len(sps))
-	//nolint:mnd
-	extradata = append(extradata, byte(spsLen>>8), byte(spsLen&0xff))
-	// SPS data
-	extradata = append(extradata, sps...)
-	// Number of Picture Parameter Sets (usually 1)
-	extradata = append(extradata, 1)
-	// PPS length (2 bytes big-endian)
-	ppsLen := uint16(len(pps))
-	//nolint:mnd
-	extradata = append(extradata, byte(ppsLen>>8), byte(ppsLen&0xff))
-	// PPS data
-	extradata = append(extradata, pps...)
-
-	// hexdump := hex.Dump(extradata)
-	// fmt.Println("extradata: \n", hexdump)
-	return extradata, nil
+	rs.closed = true
 }
 
 // cleanupStorage cleans up the storage directory by deleting the oldest files

--- a/videostore/rawsegmenter.go
+++ b/videostore/rawsegmenter.go
@@ -100,7 +100,7 @@ func (rs *rawSegmenter) init(width, height int) error {
 
 	if ret != C.VIDEO_STORE_RAW_SEG_RESP_OK {
 		err := errors.New("failed to initialize raw segmenter")
-		rs.logger.Errorf("%s: %d", err.Error(), ret)
+		rs.logger.Errorf("%s: %d: %s", err.Error(), ret, ffmpegError(ret))
 		return err
 	}
 	rs.cRawSeg = cRS

--- a/videostore/rawsegmenter.h
+++ b/videostore/rawsegmenter.h
@@ -1,27 +1,33 @@
 #ifndef VIAM_RAW_SEGMENTER_H
 #define VIAM_RAW_SEGMENTER_H
 #include <libavformat/avformat.h>
-typedef struct raw_seg_h264 {
+typedef struct raw_seg {
   AVFormatContext *outCtx;
-} raw_seg_h264;
+} raw_seg;
 
-int video_store_raw_seg_init_h264(struct raw_seg_h264 **ppRS, // OUT
-                                  const int segmentSeconds,   // IN
-                                  const char *outputPattern,  // IN
-                                  const char *extradata,      // IN
-                                  const size_t extradataSize, // IN
-                                  const int width,            // IN
-                                  const int height            // IN
+int video_store_raw_seg_init_h264(struct raw_seg **ppRS,     // OUT
+                                  const int segmentSeconds,  // IN
+                                  const char *outputPattern, // IN
+                                  const int width,           // IN
+                                  const int height           // IN
 );
 
-int video_store_raw_seg_write_h264_packet(struct raw_seg_h264 *rs,  // IN
-                                          const char *payload,      // IN
-                                          const size_t payloadSize, // IN
-                                          const int64_t pts,        // IN
-                                          const int isIdr           // IN
+int video_store_raw_seg_init_h265(struct raw_seg **ppRS,     // OUT
+                                  const int segmentSeconds,  // IN
+                                  const char *outputPattern, // IN
+                                  const int width,           // IN
+                                  const int height           // IN
 );
 
-int video_store_raw_seg_close(struct raw_seg_h264 **rs // OUT
+int video_store_raw_seg_write_packet(struct raw_seg *rs,       // IN
+                                     const char *payload,      // IN
+                                     const size_t payloadSize, // IN
+                                     const int64_t pts,        // IN
+                                     const int64_t dts,        // IN
+                                     const int isIdr           // IN
+);
+
+int video_store_raw_seg_close(struct raw_seg **rs // OUT
 );
 #define VIDEO_STORE_RAW_SEG_RESP_OK 0
 #define VIDEO_STORE_RAW_SEG_RESP_ERROR 1

--- a/videostore/videostore.go
+++ b/videostore/videostore.go
@@ -76,11 +76,6 @@ type VideoStore interface {
 	Close(ctx context.Context) error
 }
 
-// // Concater concatinates video files within the time range
-// type Concater interface {
-// 	Concat(from, to time.Time, path string) error
-// }
-
 // RTPVideoStore stores video derived from RTP packets and provides APIs to request the stored video
 type RTPVideoStore interface {
 	VideoStore
@@ -257,7 +252,7 @@ func (vs *videostore) Init(width, height int) error {
 	case SourceTypeFrame:
 		fallthrough
 	default:
-		return errors.New("Init unimplmented")
+		return fmt.Errorf("Init unimplmented for SourceType: %d: %s", vs.typ, vs.typ)
 	}
 }
 
@@ -268,7 +263,7 @@ func (vs *videostore) WritePacket(payload []byte, pts, dts int64, isIDR bool) er
 	case SourceTypeFrame:
 		fallthrough
 	default:
-		return errors.New("WritePacket unimplmented")
+		return fmt.Errorf("WritePacket unimplmented for SourceType: %d: %s", vs.typ, vs.typ)
 	}
 }
 
@@ -493,8 +488,6 @@ func (vs *videostore) asyncSave(ctx context.Context, from, to time.Time, path st
 
 // Close closes the video storage camera component.
 func (vs *videostore) Close(_ context.Context) error {
-	vs.logger.Infof("Close START")
-	defer vs.logger.Infof("Close END")
 	if vs.workers != nil {
 		vs.workers.Stop()
 	}
@@ -506,59 +499,3 @@ func (vs *videostore) Close(_ context.Context) error {
 	}
 	return nil
 }
-
-///*
-//	aligned(8) class AVCDecoderConfigurationRecord {
-//		   unsigned int(8) configurationVersion = 1;
-//		   unsigned int(8) AVCProfileIndication;
-//		   unsigned int(8) profile_compatibility;
-//		   unsigned int(8) AVCLevelIndication;
-//		   bit(6) reserved = ‘111111’b;
-//		   unsigned int(2) lengthSizeMinusOne;
-//		   bit(3) reserved = ‘111’b;
-//		   unsigned int(5) numOfSequenceParameterSets;
-//		   for (i=0; i< numOfSequenceParameterSets;  i++) {
-//		      unsigned int(16) sequenceParameterSetLength ;
-//		  bit(8*sequenceParameterSetLength) sequenceParameterSetNALUnit;
-//		 }
-//		   unsigned int(8) numOfPictureParameterSets;
-//		   for (i=0; i< numOfPictureParameterSets;  i++) {
-//		  unsigned int(16) pictureParameterSetLength;
-//		  bit(8*pictureParameterSetLength) pictureParameterSetNALUnit;
-//		 }
-//		}
-//*/
-//// BuildAVCExtradata builds the AVCDecoderConfigurationRecord extradata from the SPS and PPS data.
-//// The SPS and PPS data are expected to be packed into the format listed above.
-//func BuildAVCExtradata(sps, pps []byte) ([]byte, error) {
-//	if len(sps) < 4 || len(pps) < 1 {
-//		return nil, errors.New("invalid SPS/PPS data")
-//	}
-//	extradata := []byte{}
-//	// configurationVersion
-//	extradata = append(extradata, 1)
-//	// AVCProfileIndication, profile_compatibility, AVCLevelIndication (from SPS)
-//	extradata = append(extradata, sps[1], sps[2], sps[3])
-//	// 6 bits reserved (111111) + 2 bits lengthSizeMinusOne (3 for 4 bytes)
-//	//nolint:mnd
-//	extradata = append(extradata, 0xFF)
-//	// 3 bits reserved (111) + 5 bits numOfSequenceParameterSets (usually 1)
-//	//nolint:mnd
-//	extradata = append(extradata, 0xE1)
-//	// SPS length (2 bytes big-endian)
-//	spsLen := uint16(len(sps))
-//	//nolint:mnd
-//	extradata = append(extradata, byte(spsLen>>8), byte(spsLen&0xff))
-//	// SPS data
-//	extradata = append(extradata, sps...)
-//	// Number of Picture Parameter Sets (usually 1)
-//	extradata = append(extradata, 1)
-//	// PPS length (2 bytes big-endian)
-//	ppsLen := uint16(len(pps))
-//	//nolint:mnd
-//	extradata = append(extradata, byte(ppsLen>>8), byte(ppsLen&0xff))
-//	// PPS data
-//	extradata = append(extradata, pps...)
-
-//	return extradata, nil
-//}

--- a/videostore/videostore.go
+++ b/videostore/videostore.go
@@ -73,7 +73,7 @@ type videostore struct {
 type VideoStore interface {
 	Fetch(ctx context.Context, r *FetchRequest) (*FetchResponse, error)
 	Save(ctx context.Context, r *SaveRequest) (*SaveResponse, error)
-	Close(ctx context.Context) error
+	Close()
 }
 
 // RTPVideoStore stores video derived from RTP packets and provides APIs to request the stored video
@@ -487,7 +487,7 @@ func (vs *videostore) asyncSave(ctx context.Context, from, to time.Time, path st
 }
 
 // Close closes the video storage camera component.
-func (vs *videostore) Close(_ context.Context) error {
+func (vs *videostore) Close() {
 	if vs.workers != nil {
 		vs.workers.Stop()
 	}
@@ -497,5 +497,4 @@ func (vs *videostore) Close(_ context.Context) error {
 	if vs.rawSegmenter != nil {
 		vs.rawSegmenter.close()
 	}
-	return nil
 }


### PR DESCRIPTION
1. Add support for saving h265 video via the rawpacketizer including tags for QuickTime compatibility.
2. Change the signature of rawpacketizer to allow the caller to provide dts and not require extradata to be provided prior to writing the first packet.
3. Fix bug where if 2 whole segement files were concatenated the dts would repeat causing concatenation to fail.