### PR TITLE
[RSDK-10116] - Wrap default log callback with flush

### DIFF
--- a/cmd/module/cmd.go
+++ b/cmd/module/cmd.go
@@ -18,10 +18,12 @@ func main() {
 
 func mainWithArgs(ctx context.Context, _ []string, logger logging.Logger) error {
 	if logger.GetLevel() == logging.DEBUG {
-		videostore.SetLibAVLogLevel("info")
+		videostore.SetLibAVLogLevel("debug")
 	} else {
 		videostore.SetLibAVLogLevel("error")
 	}
+	videostore.SetFFmpegLogCallback()
+
 	module, err := module.NewModuleFromArgs(ctx)
 	if err != nil {
 		return err

--- a/videostore/utils.c
+++ b/videostore/utils.c
@@ -20,3 +20,21 @@ int get_video_duration(int64_t *duration,   // OUT
     avformat_close_input(&fmt_ctx);
     return VIDEO_STORE_DURATION_RESP_OK;
 }
+
+void custom_av_log_callback(void *ptr, int level, const char *fmt, va_list vargs) {
+    // Default callback will handle log level filtering
+    av_log_default_callback(ptr, level, fmt, vargs);
+    // Default callback only prints to stderr
+    fflush(stderr);
+}
+
+void set_custom_av_log_callback() {
+    av_log_set_callback(custom_av_log_callback);
+}
+
+void test_av_log() {
+    av_log(NULL, AV_LOG_ERROR, "This is an error message\n");
+    av_log(NULL, AV_LOG_INFO, "This is an info message\n");
+    av_log(NULL, AV_LOG_DEBUG, "This is a debug message\n");
+    av_log(NULL, AV_LOG_TRACE, "This is a trace message\n");
+}

--- a/videostore/utils.c
+++ b/videostore/utils.c
@@ -31,10 +31,3 @@ void custom_av_log_callback(void *ptr, int level, const char *fmt, va_list vargs
 void set_custom_av_log_callback() {
     av_log_set_callback(custom_av_log_callback);
 }
-
-void test_av_log() {
-    av_log(NULL, AV_LOG_ERROR, "This is an error message\n");
-    av_log(NULL, AV_LOG_INFO, "This is an info message\n");
-    av_log(NULL, AV_LOG_DEBUG, "This is a debug message\n");
-    av_log(NULL, AV_LOG_TRACE, "This is a trace message\n");
-}

--- a/videostore/utils.go
+++ b/videostore/utils.go
@@ -104,7 +104,7 @@ func ffmpegLogLevel(loglevel C.int) {
 	C.av_log_set_level(loglevel)
 }
 
-// ffmpegLogCallback sets the custom log callback for ffmpeg.
+// SetFFmpegLogCallback sets the custom log callback for ffmpeg.
 func SetFFmpegLogCallback() {
 	C.set_custom_av_log_callback()
 }

--- a/videostore/utils.go
+++ b/videostore/utils.go
@@ -28,7 +28,7 @@ import (
 // valid inputs are "info", "warn", "error", "debug"
 // https://www.ffmpeg.org/doxygen/2.5/group__lavu__log__constants.html
 func SetLibAVLogLevel(level string) {
-	ffmppegLogLevel(lookupLogID(level))
+	ffmpegLogLevel(lookupLogID(level))
 }
 
 type codecType int
@@ -99,9 +99,14 @@ func ffmpegError(ret C.int) string {
 	return C.GoString(&errbuf[0])
 }
 
-// ffmppegLogLevel sets the log level for ffmpeg logger.
-func ffmppegLogLevel(loglevel C.int) {
+// ffmpegLogLevel sets the log level for ffmpeg logger.
+func ffmpegLogLevel(loglevel C.int) {
 	C.av_log_set_level(loglevel)
+}
+
+// ffmpegLogCallback sets the custom log callback for ffmpeg.
+func SetFFmpegLogCallback() {
+	C.set_custom_av_log_callback()
 }
 
 // lookupLogID returns the log ID for the provided log level.

--- a/videostore/utils.h
+++ b/videostore/utils.h
@@ -2,6 +2,9 @@
 #define VIAM_VIDEOSTORE_UTILS_H
 #include <libavformat/avformat.h>
 int get_video_duration(int64_t *duration, const char *filename);
+void custom_av_log_callback(void *ptr, int level, const char *fmt, va_list vargs);
+void set_custom_av_log_callback();
+void test_av_log();
 #define VIDEO_STORE_DURATION_RESP_ERROR 1
 #define VIDEO_STORE_DURATION_RESP_OK 0
 #endif /* VIAM_VIDEOSTORE_UTILS_H */

--- a/videostore/utils.h
+++ b/videostore/utils.h
@@ -4,7 +4,6 @@
 int get_video_duration(int64_t *duration, const char *filename);
 void custom_av_log_callback(void *ptr, int level, const char *fmt, va_list vargs);
 void set_custom_av_log_callback();
-void test_av_log();
 #define VIDEO_STORE_DURATION_RESP_ERROR 1
 #define VIDEO_STORE_DURATION_RESP_OK 0
 #endif /* VIAM_VIDEOSTORE_UTILS_H */


### PR DESCRIPTION
## Description

See [ticket](https://viam.atlassian.net/browse/RSDK-10116) for description of problem flushing av logs in our C code. This PR just wraps the default logger from FFmpeg with a `fflush` to `stderr`.

## Testing

Manual testing with `test_av_log` helper that logs now show up.

```
2025-03-06T18:18:39.105Z	ERROR	rdk.modmanager.viam_video-store.viam_video-store.StdErr	pexec/managed_process.go:292	
\_ This is an error message
2025-03-06T18:18:39.106Z	ERROR	rdk.modmanager.viam_video-store.viam_video-store.StdErr	pexec/managed_process.go:292	
\_ This is an info message
2025-03-06T18:18:39.106Z	ERROR	rdk.modmanager.viam_video-store.viam_video-store.StdErr	pexec/managed_process.go:292	
\_ This is a debug message

```