### PR TITLE
[RSDK-10002] - make video store viamrtsp model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.1
 require (
 	github.com/AlekSi/gocov-xml v1.0.0
 	github.com/axw/gocov v1.1.0
-	github.com/bluenviron/mediacommon v1.9.2
+	github.com/bluenviron/mediacommon v1.13.3
 	github.com/edaniels/golinters v0.0.5-0.20220906153528-641155550742
 	github.com/fullstorydev/grpcurl v1.8.6
 	github.com/golangci/golangci-lint v1.61.0
@@ -273,7 +273,7 @@ require (
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.1.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/tdakkota/asciicheck v0.2.0 // indirect
 	github.com/tetafro/godot v1.4.17 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ toolchain go1.23.1
 require (
 	github.com/AlekSi/gocov-xml v1.0.0
 	github.com/axw/gocov v1.1.0
-	github.com/bluenviron/mediacommon v1.13.3
 	github.com/edaniels/golinters v0.0.5-0.20220906153528-641155550742
 	github.com/fullstorydev/grpcurl v1.8.6
 	github.com/golangci/golangci-lint v1.61.0
@@ -60,6 +59,7 @@ require (
 	github.com/blackjack/webcam v0.6.1 // indirect
 	github.com/blizzy78/varnamelen v0.8.0 // indirect
 	github.com/bluenviron/gortsplib/v4 v4.8.0 // indirect
+	github.com/bluenviron/mediacommon v1.13.3 // indirect
 	github.com/bombsimon/wsl/v4 v4.4.1 // indirect
 	github.com/breml/bidichk v0.2.7 // indirect
 	github.com/breml/errchkjson v0.3.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.23.1
 require (
 	github.com/AlekSi/gocov-xml v1.0.0
 	github.com/axw/gocov v1.1.0
+	github.com/bluenviron/mediacommon v1.9.2
 	github.com/edaniels/golinters v0.0.5-0.20220906153528-641155550742
 	github.com/fullstorydev/grpcurl v1.8.6
 	github.com/golangci/golangci-lint v1.61.0
@@ -59,7 +60,6 @@ require (
 	github.com/blackjack/webcam v0.6.1 // indirect
 	github.com/blizzy78/varnamelen v0.8.0 // indirect
 	github.com/bluenviron/gortsplib/v4 v4.8.0 // indirect
-	github.com/bluenviron/mediacommon v1.9.2 // indirect
 	github.com/bombsimon/wsl/v4 v4.4.1 // indirect
 	github.com/breml/bidichk v0.2.7 // indirect
 	github.com/breml/errchkjson v0.3.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/blizzy78/varnamelen v0.8.0 h1:oqSblyuQvFsW1hbBHh1zfwrKe3kcSj0rnXkKzsQ
 github.com/blizzy78/varnamelen v0.8.0/go.mod h1:V9TzQZ4fLJ1DSrjVDfl89H7aMnTvKkApdHeyESmyR7k=
 github.com/bluenviron/gortsplib/v4 v4.8.0 h1:nvFp6rHALcSep3G9uBFI0uogS9stVZLNq/92TzGZdQg=
 github.com/bluenviron/gortsplib/v4 v4.8.0/go.mod h1:+d+veuyvhvikUNp0GRQkk6fEbd/DtcXNidMRm7FQRaA=
-github.com/bluenviron/mediacommon v1.9.2 h1:EHcvoC5YMXRcFE010bTNf07ZiSlB/e/AdZyG7GsEYN0=
-github.com/bluenviron/mediacommon v1.9.2/go.mod h1:lt8V+wMyPw8C69HAqDWV5tsAwzN9u2Z+ca8B6C//+n0=
+github.com/bluenviron/mediacommon v1.13.3 h1:PgprN9mAd/F5ew7Ym+UZCiCJstQVT5mZXtmN9JZvv4Y=
+github.com/bluenviron/mediacommon v1.13.3/go.mod h1:RrO01FltoVUlTBGXbOYtmx1ft1oBOpLxfNGsYlaFAO8=
 github.com/bombsimon/wsl/v3 v3.2.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
 github.com/bombsimon/wsl/v4 v4.4.1 h1:jfUaCkN+aUpobrMO24zwyAMwMAV5eSziCkOKEauOLdw=
 github.com/bombsimon/wsl/v4 v4.4.1/go.mod h1:Xu/kDxGZTofQcDGCtQe9KCzhHphIe0fDuyWTxER9Feo=
@@ -1192,8 +1192,9 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/subosito/gotenv v1.4.1 h1:jyEFiXpy21Wm81FBN71l9VoMMV8H8jG+qIK3GCpY6Qs=
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=

--- a/videostore/config.go
+++ b/videostore/config.go
@@ -20,7 +20,7 @@ const (
 	SourceTypeFrame
 	// SourceTypeRTP is a video store that creates a video from rtp packets.
 	SourceTypeRTP
-	// SourceTypeReadOnly is a video store that only reads already stored segment files
+	// SourceTypeReadOnly is a video store that only reads already stored segment files.
 	SourceTypeReadOnly
 )
 

--- a/videostore/config.go
+++ b/videostore/config.go
@@ -18,10 +18,10 @@ const (
 	SourceTypeUnknown SourceType = iota
 	// SourceTypeFrame is a video store that creates a video from frames.
 	SourceTypeFrame
-	// SourceTypeH264RTPPacket is a video store that creates a video from rtp packets.
-	SourceTypeH264RTPPacket
-	// SourceTypeH265RTPPacket is a video store that creates a video from rtp packets.
-	SourceTypeH265RTPPacket
+	// SourceTypeRTP is a video store that creates a video from rtp packets.
+	SourceTypeRTP
+	// SourceTypeReadOnly is a video store that only reads already stored segment files
+	SourceTypeReadOnly
 )
 
 func (t SourceType) String() string {
@@ -30,10 +30,10 @@ func (t SourceType) String() string {
 		return "VideoStoreTypeUnknown"
 	case SourceTypeFrame:
 		return "VideoStoreTypeFrame"
-	case SourceTypeH264RTPPacket:
-		return "SourceTypeH264RTPPacket"
-	case SourceTypeH265RTPPacket:
-		return "SourceTypeH265RTPPacket"
+	case SourceTypeRTP:
+		return "SourceTypeRTP"
+	case SourceTypeReadOnly:
+		return "SourceTypeReadOnly"
 	default:
 		return "VideoStoreTypeUnknown"
 	}

--- a/videostore/rawsegmenter.go
+++ b/videostore/rawsegmenter.go
@@ -61,17 +61,13 @@ func newRawSegmenter(
 // Note: May write to disk
 func (rs *RawSegmenter) Init(codec CodecType, width, height int) error {
 	if width <= 0 || height <= 0 {
-		err := errors.New("both width and height must be greater than zero")
-		rs.logger.Warn(err.Error())
-		return err
+		return errors.New("both width and height must be greater than zero")
 	}
 
 	rs.cRawSegMu.Lock()
 	defer rs.cRawSegMu.Unlock()
 	if rs.cRawSeg != nil {
-		err := errors.New("*rawSegmenter init called more than once")
-		rs.logger.Warn(err.Error())
-		return err
+		return errors.New("*rawSegmenter init called more than once")
 	}
 
 	var cRS *C.raw_seg
@@ -97,9 +93,7 @@ func (rs *RawSegmenter) Init(codec CodecType, width, height int) error {
 			C.int(width),
 			C.int(height))
 	default:
-		err := fmt.Errorf("rawSegmenter.Init called on invalid codec %s", codec)
-		rs.logger.Warn(err.Error())
-		return err
+		return fmt.Errorf("rawSegmenter.Init called on invalid codec %s", codec)
 	}
 
 	if ret != C.VIDEO_STORE_RAW_SEG_RESP_OK {
@@ -118,15 +112,11 @@ func (rs *RawSegmenter) WritePacket(payload []byte, pts, dts int64, isIDR bool) 
 	rs.cRawSegMu.Lock()
 	defer rs.cRawSegMu.Unlock()
 	if rs.cRawSeg == nil {
-		err := errors.New("writePacket called before init")
-		rs.logger.Warn(err.Error())
-		return err
+		return errors.New("writePacket called before init")
 	}
 
 	if len(payload) == 0 {
-		err := errors.New("writePacket called with empty packet")
-		rs.logger.Warn(err.Error())
-		return err
+		return errors.New("writePacket called with empty packet")
 	}
 
 	payloadC := C.CBytes(payload)
@@ -157,16 +147,6 @@ func (rs *RawSegmenter) WritePacket(payload []byte, pts, dts int64, isIDR bool) 
 func (rs *RawSegmenter) Close() error {
 	rs.cRawSegMu.Lock()
 	defer rs.cRawSegMu.Unlock()
-	err := rs.close()
-	if err != nil {
-		rs.logger.Warnf("RawSegmenter.Close err: %s", err.Error())
-		return err
-	}
-	return nil
-}
-
-// close must be called while the caller holds cRawSegMu
-func (rs *RawSegmenter) close() error {
 	if rs.cRawSeg == nil {
 		return nil
 	}

--- a/videostore/rawsegmenter.go
+++ b/videostore/rawsegmenter.go
@@ -15,7 +15,7 @@ import (
 	"go.viam.com/rdk/logging"
 )
 
-type RawSegmenter struct {
+type rawSegmenter struct {
 	logger         logging.Logger
 	storagePath    string
 	segmentSeconds int
@@ -42,8 +42,8 @@ func newRawSegmenter(
 	logger logging.Logger,
 	storagePath string,
 	segmentSeconds int,
-) (*RawSegmenter, error) {
-	s := &RawSegmenter{
+) (*rawSegmenter, error) {
+	s := &rawSegmenter{
 		logger:         logger,
 		storagePath:    storagePath,
 		segmentSeconds: segmentSeconds,
@@ -55,8 +55,7 @@ func newRawSegmenter(
 	return s, nil
 }
 
-func (rs *RawSegmenter) Init(codec CodecType, width, height int) error {
-	rs.logger.Infof("RawSegmenter.Init START with: %s, %dx%d", codec, width, height)
+func (rs *rawSegmenter) Init(codec CodecType, width, height int) error {
 	if width <= 0 || height <= 0 {
 		err := errors.New("both width and height must be greater than zero")
 		rs.logger.Warn(err.Error())
@@ -106,12 +105,10 @@ func (rs *RawSegmenter) Init(codec CodecType, width, height int) error {
 	}
 	rs.cRawSeg = cRS
 
-	rs.logger.Infof("RawSegmenter.Init SUCCEEDED with: %s, %dx%d", codec, width, height)
 	return nil
 }
 
-func (rs *RawSegmenter) WritePacket(payload []byte, pts, dts int64, isIDR bool) error {
-	rs.logger.Infof("RawSegmenter.WritePacket START with: len(payload): %d, pts: %d, dts: %d, isIDR: %t", len(payload), pts, dts, isIDR)
+func (rs *rawSegmenter) WritePacket(payload []byte, pts, dts int64, isIDR bool) error {
 	rs.cRawSegMu.Lock()
 	defer rs.cRawSegMu.Unlock()
 	if rs.cRawSeg == nil {
@@ -145,14 +142,12 @@ func (rs *RawSegmenter) WritePacket(payload []byte, pts, dts int64, isIDR bool) 
 		rs.logger.Errorf("%s: %d", err.Error(), ret)
 		return err
 	}
-	rs.logger.Infof("RawSegmenter.WritePacket SUCCEEDED with: len(payload): %d, pts: %d, dts: %d, isIDR: %t", len(payload), pts, dts, isIDR)
 	return nil
 }
 
 // Close closes the segmenter and writes the trailer to prevent corruption
 // when exiting early in the middle of a segment.
-func (rs *RawSegmenter) Close() error {
-	rs.logger.Info("RawSegmenter.Close START")
+func (rs *rawSegmenter) Close() error {
 	rs.cRawSegMu.Lock()
 	defer rs.cRawSegMu.Unlock()
 	err := rs.close()
@@ -160,12 +155,11 @@ func (rs *RawSegmenter) Close() error {
 		rs.logger.Warnf("RawSegmenter.Close err: %s", err.Error())
 		return err
 	}
-	rs.logger.Info("RawSegmenter.Close SUCCEEDED")
 	return nil
 }
 
 // close must be called while the caller holds cRawSegMu
-func (rs *RawSegmenter) close() error {
+func (rs *rawSegmenter) close() error {
 	if rs.cRawSeg == nil {
 		return nil
 	}

--- a/videostore/rawsegmenter.go
+++ b/videostore/rawsegmenter.go
@@ -9,7 +9,6 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	"os"
 	"sync"
 	"unsafe"
 
@@ -22,32 +21,18 @@ type rawSegmenter struct {
 	storagePath    string
 	segmentSeconds int
 	mu             sync.Mutex
-	initialized    bool
-	closed         bool
-	maxStorageSize int64
 	cRawSeg        *C.raw_seg
 }
 
 func newRawSegmenter(
 	logger logging.Logger,
-	typ SourceType,
-	storageSize int,
 	storagePath string,
 	segmentSeconds int,
 ) (*rawSegmenter, error) {
-	switch typ {
-	case SourceTypeH264RTPPacket, SourceTypeH265RTPPacket:
-	case SourceTypeFrame:
-		return nil, fmt.Errorf("newRawSegmenter called with unsupported SourceType %d: %s", typ, typ)
-	default:
-		return nil, fmt.Errorf("newRawSegmenter called with unsupported SourceType %d: %s", typ, typ)
-	}
 	s := &rawSegmenter{
-		typ:            typ,
 		logger:         logger,
 		storagePath:    storagePath,
 		segmentSeconds: segmentSeconds,
-		maxStorageSize: int64(storageSize) * gigabyte,
 	}
 	err := createDir(s.storagePath)
 	if err != nil {
@@ -56,20 +41,17 @@ func newRawSegmenter(
 	return s, nil
 }
 
-func (rs *rawSegmenter) init(width, height int) error {
+func (rs *rawSegmenter) init(codec CodecType, width, height int) error {
 	if width <= 0 || height <= 0 {
 		return errors.New("both width and height must be greater than zero")
 	}
 
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
-	if rs.initialized {
+	if rs.cRawSeg != nil {
 		return errors.New("*rawSegmenter init called more than once")
 	}
 
-	if rs.closed {
-		return errors.New("*rawSegmenter init called after close")
-	}
 	var cRS *C.raw_seg
 	// Allocate output context for segmenter. The "segment" format is a special format
 	// that allows for segmenting output files. The output pattern is a strftime pattern
@@ -77,25 +59,23 @@ func (rs *rawSegmenter) init(width, height int) error {
 	outputPatternCStr := C.CString(rs.storagePath + "/" + outputPattern)
 	defer C.free(unsafe.Pointer(outputPatternCStr))
 	var ret C.int
-	switch rs.typ {
-	case SourceTypeH264RTPPacket:
+	switch codec {
+	case CodecTypeH264:
 		ret = C.video_store_raw_seg_init_h264(
 			&cRS,
 			C.int(rs.segmentSeconds),
 			outputPatternCStr,
 			C.int(width),
 			C.int(height))
-	case SourceTypeH265RTPPacket:
+	case CodecTypeH265:
 		ret = C.video_store_raw_seg_init_h265(
 			&cRS,
 			C.int(rs.segmentSeconds),
 			outputPatternCStr,
 			C.int(width),
 			C.int(height))
-	case SourceTypeFrame:
-		fallthrough
 	default:
-		return fmt.Errorf("rawSegmenter.init called on invalid SourceType %d: %s", rs.typ, rs.typ)
+		return fmt.Errorf("rawSegmenter.init called on invalid codec %s", codec)
 	}
 
 	if ret != C.VIDEO_STORE_RAW_SEG_RESP_OK {
@@ -104,7 +84,6 @@ func (rs *rawSegmenter) init(width, height int) error {
 		return err
 	}
 	rs.cRawSeg = cRS
-	rs.initialized = true
 
 	return nil
 }
@@ -112,12 +91,8 @@ func (rs *rawSegmenter) init(width, height int) error {
 func (rs *rawSegmenter) writePacket(payload []byte, pts, dts int64, isIDR bool) error {
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
-	if !rs.initialized {
+	if rs.cRawSeg == nil {
 		return errors.New("writePacket called before init")
-	}
-
-	if rs.closed {
-		return errors.New("writePacket called after close")
 	}
 
 	if len(payload) == 0 {
@@ -148,54 +123,16 @@ func (rs *rawSegmenter) writePacket(payload []byte, pts, dts int64, isIDR bool) 
 
 // close closes the segmenter and writes the trailer to prevent corruption
 // when exiting early in the middle of a segment.
-func (rs *rawSegmenter) close() {
+func (rs *rawSegmenter) close() error {
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
-	if !rs.initialized {
-		return
-	}
-	if rs.closed {
-		return
+	if rs.cRawSeg == nil {
+		return nil
 	}
 	ret := C.video_store_raw_seg_close(&rs.cRawSeg)
 	if ret != C.VIDEO_STORE_RAW_SEG_RESP_OK {
-		rs.logger.Errorf("failed to close raw segmeneter: %d", ret)
+		return fmt.Errorf("failed to close raw segmeneter: %d", ret)
 	}
-	rs.closed = true
-}
-
-// cleanupStorage cleans up the storage directory by deleting the oldest files
-// until the storage size is below the max.
-func (rs *rawSegmenter) cleanupStorage() error {
-	rs.logger.Info("cleanupStorage start")
-	defer rs.logger.Info("cleanupStorage stop")
-	currStorageSize, err := getDirectorySize(rs.storagePath)
-	if err != nil {
-		return err
-	}
-	if currStorageSize < rs.maxStorageSize {
-		return nil
-	}
-	files, err := getSortedFiles(rs.storagePath)
-	if err != nil {
-		return err
-	}
-	for _, file := range files {
-		if currStorageSize < rs.maxStorageSize {
-			break
-		}
-		rs.logger.Debugf("deleting file: %s", file)
-		err := os.Remove(file)
-		if err != nil {
-			return err
-		}
-		rs.logger.Debugf("deleted file: %s", file)
-		// NOTE: This is going to be super slow
-		// we should speed this up
-		currStorageSize, err = getDirectorySize(rs.storagePath)
-		if err != nil {
-			return err
-		}
-	}
+	rs.cRawSeg = nil
 	return nil
 }

--- a/videostore/rawsegmenter.go
+++ b/videostore/rawsegmenter.go
@@ -97,7 +97,7 @@ func (rs *RawSegmenter) Init(codec CodecType, width, height int) error {
 			C.int(width),
 			C.int(height))
 	default:
-		err := fmt.Errorf("rawSegmenter.init called on invalid codec %s", codec)
+		err := fmt.Errorf("rawSegmenter.Init called on invalid codec %s", codec)
 		rs.logger.Warn(err.Error())
 		return err
 	}

--- a/videostore/segmenter.go
+++ b/videostore/segmenter.go
@@ -13,7 +13,6 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"sync"
 	"unsafe"
@@ -183,42 +182,6 @@ func (s *segmenter) writeEncodedFrame(encodedData []byte, pts, dts int64) error 
 		return fmt.Errorf("failed to write frame: %s", ffmpegError(ret))
 	}
 	s.frameCount++
-	return nil
-}
-
-// cleanupStorage cleans up the storage directory by deleting the oldest files
-// until the storage size is below the max.
-func (s *segmenter) cleanupStorage() error {
-	s.logger.Info("cleanupStorage start")
-	defer s.logger.Info("cleanupStorage stop")
-	currStorageSize, err := getDirectorySize(s.storagePath)
-	if err != nil {
-		return err
-	}
-	if currStorageSize < s.maxStorageSize {
-		return nil
-	}
-	files, err := getSortedFiles(s.storagePath)
-	if err != nil {
-		return err
-	}
-	for _, file := range files {
-		if currStorageSize < s.maxStorageSize {
-			break
-		}
-		s.logger.Debugf("deleting file: %s", file)
-		err := os.Remove(file)
-		if err != nil {
-			return err
-		}
-		s.logger.Debugf("deleted file: %s", file)
-		// NOTE: This is going to be super slow
-		// we should speed this up
-		currStorageSize, err = getDirectorySize(s.storagePath)
-		if err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/videostore/videostore.go
+++ b/videostore/videostore.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -67,11 +68,10 @@ type videostore struct {
 	latestFrame atomic.Pointer[C.AVFrame]
 	workers     *utils.StoppableWorkers
 
-	rawSegmenter *rawSegmenter
-	// TODO: maybe protect with mutext?
-	vps, sps, pps []byte
-	segmenter     *segmenter
-	concater      *concater
+	// rawSegmenter *rawSegmenter
+	videoStoreMuxer *rawSegmenterMux
+	segmenter       *segmenter
+	concater        *concater
 }
 
 // VideoStore stores video and provides APIs to request the stored video
@@ -108,7 +108,7 @@ func (t CodecType) String() string {
 type RTPSegmenter interface {
 	SupportedCodecs() map[CodecType]struct{}
 	SDPParams(codec CodecType, au [][]byte) error
-	WritePacket(au [][]byte, pts int64) error
+	WritePacket(codec CodecType, au [][]byte, pts int64) error
 	CloseSegmenter() error
 }
 
@@ -284,12 +284,15 @@ func NewRTPVideoStore(config Config, logger logging.Logger) (RTPVideoStore, erro
 	}
 
 	vs := &videostore{
-		typ:          config.Type,
-		concater:     concater,
-		rawSegmenter: rawSegmenter,
-		logger:       logger,
-		config:       config,
-		workers:      utils.NewBackgroundStoppableWorkers(),
+		typ:      config.Type,
+		concater: concater,
+		videoStoreMuxer: &rawSegmenterMux{
+			rawSeg: rawSegmenter,
+			logger: logger,
+		},
+		logger:  logger,
+		config:  config,
+		workers: utils.NewBackgroundStoppableWorkers(),
 	}
 
 	vs.workers.Add(vs.deleter)
@@ -307,58 +310,21 @@ func (vs *videostore) SDPParams(codec CodecType, au [][]byte) error {
 	if vs.typ != SourceTypeRTP {
 		return fmt.Errorf("Init unimplmented for SourceType: %d: %s", vs.typ, vs.typ)
 	}
-	var width, height int
-	switch codec {
-	case CodecTypeH264:
-		for _, nalu := range au {
-			//nolint:mnd
-			typ := h264.NALUType(nalu[0] & 0x1F)
-			switch typ {
-			case h264.NALUTypeSPS:
-				vs.sps = nalu
-			case h264.NALUTypePPS:
-				vs.pps = nalu
-			default:
-				return errors.New("invalid nalu")
-			}
-		}
-	case CodecTypeH265:
-		for _, nalu := range au {
-			//nolint:mnd
-			typ := h265.NALUType((nalu[0] >> 1) & 0b111111)
-			switch typ {
-			case h265.NALUType_VPS_NUT:
-				vs.vps = nalu
-
-			case h265.NALUType_SPS_NUT:
-				vs.sps = nalu
-
-			case h265.NALUType_PPS_NUT:
-				vs.pps = nalu
-			default:
-				return errors.New("invalid nalu")
-			}
-		}
-	default:
-		return errors.New("invalid codec")
-	}
-	return vs.rawSegmenter.init(codec, width, height)
+	return vs.videoStoreMuxer.sdpParams(codec, au)
 }
 
-func (vs *videostore) WritePacket(au [][]byte, pts int64) error {
+func (vs *videostore) WritePacket(codec CodecType, au [][]byte, pts int64) error {
 	if vs.typ != SourceTypeRTP {
 		return fmt.Errorf("WritePacket unimplmented for SourceType: %d: %s", vs.typ, vs.typ)
 	}
-	return nil
-	// TODO: Nick Move muxer in here
-	// return vs.rawSegmenter.writePacket(payload, pts, dts, isIDR)
+	return vs.videoStoreMuxer.writePacket(codec, au, pts)
 }
 
 func (vs *videostore) CloseSegmenter() error {
 	if vs.typ != SourceTypeRTP {
 		return fmt.Errorf("CloseSegmenter unimplmented for SourceType: %d: %s", vs.typ, vs.typ)
 	}
-	if err := vs.rawSegmenter.close(); err != nil {
+	if err := vs.videoStoreMuxer.close(); err != nil {
 		return err
 	}
 	return nil
@@ -627,7 +593,359 @@ func (vs *videostore) Close() {
 	if vs.segmenter != nil {
 		vs.segmenter.close()
 	}
-	if vs.rawSegmenter != nil {
-		vs.rawSegmenter.close()
+	if vs.videoStoreMuxer != nil {
+		vs.videoStoreMuxer.close()
 	}
+}
+
+type extractor interface {
+	Extract(au [][]byte, pts int64) (int64, error)
+}
+
+type rawSegmenterMux struct {
+	codec        CodecType
+	width        int
+	height       int
+	vps          []byte
+	sps          []byte
+	pps          []byte
+	dtsExtractor extractor
+	spsUnChanged bool
+	mu           sync.Mutex
+	rawSeg       *rawSegmenter
+	logger       logging.Logger
+}
+
+func (e *rawSegmenterMux) sdpParams(codec CodecType, au [][]byte) error {
+	if e.codec != CodecTypeUnknown {
+		return fmt.Errorf("SDPParams called when codec already set to %s", e.codec)
+	}
+	switch codec {
+	case CodecTypeH264:
+		for _, nalu := range au {
+			//nolint:mnd
+			typ := h264.NALUType(nalu[0] & 0x1F)
+			switch typ {
+			case h264.NALUTypeSPS:
+				e.sps = nalu
+			case h264.NALUTypePPS:
+				e.pps = nalu
+			default:
+				return errors.New("invalid nalu")
+			}
+		}
+	case CodecTypeH265:
+		for _, nalu := range au {
+			//nolint:mnd
+			typ := h265.NALUType((nalu[0] >> 1) & 0b111111)
+			switch typ {
+			case h265.NALUType_VPS_NUT:
+				e.vps = nalu
+
+			case h265.NALUType_SPS_NUT:
+				e.sps = nalu
+
+			case h265.NALUType_PPS_NUT:
+				e.pps = nalu
+			default:
+				return errors.New("invalid nalu")
+			}
+		}
+	default:
+		return errors.New("invalid codec")
+	}
+	e.codec = codec
+	return nil
+}
+
+func (e *rawSegmenterMux) writePacket(codec CodecType, au [][]byte, pts int64) error {
+	if e.codec == CodecTypeUnknown {
+		return errors.New("WritePacket called before SDPParams")
+	}
+
+	if e.codec != codec {
+		return errors.New("WritePacket called with different codec than SDPParams")
+	}
+
+	switch codec {
+	case CodecTypeH264:
+		return e.writeH264(au, pts)
+	case CodecTypeH265:
+		return e.writeH265(au, pts)
+	default:
+		return errors.New("invalid codec")
+	}
+}
+
+func (e *rawSegmenterMux) writeH265(au [][]byte, pts int64) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	var filteredAU [][]byte
+
+	isRandomAccess := false
+
+	for _, nalu := range au {
+		//nolint:mnd
+		typ := h265.NALUType((nalu[0] >> 1) & 0b111111)
+		switch typ {
+		case h265.NALUType_VPS_NUT:
+			e.vps = nalu
+			continue
+
+		case h265.NALUType_SPS_NUT:
+			e.sps = nalu
+			e.spsUnChanged = false
+			continue
+
+		case h265.NALUType_PPS_NUT:
+			e.pps = nalu
+			continue
+
+		case h265.NALUType_AUD_NUT:
+			continue
+
+		case h265.NALUType_IDR_W_RADL, h265.NALUType_IDR_N_LP, h265.NALUType_CRA_NUT:
+			isRandomAccess = true
+		case h265.NALUType_TRAIL_N,
+			h265.NALUType_TRAIL_R,
+			h265.NALUType_TSA_N,
+			h265.NALUType_TSA_R,
+			h265.NALUType_STSA_N,
+			h265.NALUType_STSA_R,
+			h265.NALUType_RADL_N,
+			h265.NALUType_RADL_R,
+			h265.NALUType_RASL_N,
+			h265.NALUType_RASL_R,
+			h265.NALUType_RSV_VCL_N10,
+			h265.NALUType_RSV_VCL_N12,
+			h265.NALUType_RSV_VCL_N14,
+			h265.NALUType_RSV_VCL_R11,
+			h265.NALUType_RSV_VCL_R13,
+			h265.NALUType_RSV_VCL_R15,
+			h265.NALUType_BLA_W_LP,
+			h265.NALUType_BLA_W_RADL,
+			h265.NALUType_BLA_N_LP,
+			h265.NALUType_RSV_IRAP_VCL22,
+			h265.NALUType_RSV_IRAP_VCL23,
+			h265.NALUType_EOS_NUT,
+			h265.NALUType_EOB_NUT,
+			h265.NALUType_FD_NUT,
+			h265.NALUType_PREFIX_SEI_NUT,
+			h265.NALUType_SUFFIX_SEI_NUT,
+			h265.NALUType_AggregationUnit,
+			h265.NALUType_FragmentationUnit,
+			h265.NALUType_PACI:
+		default:
+			return errors.New("invalid nalu")
+		}
+
+		filteredAU = append(filteredAU, nalu)
+	}
+
+	au = filteredAU
+
+	if au == nil {
+		return nil
+	}
+
+	if err := e.maybeReInitVideoStore(); err != nil {
+		e.logger.Debugf("unable to init video store: %s", err.Error())
+		return nil
+	}
+
+	// add VPS, SPS and PPS before random access au
+	if isRandomAccess {
+		au = append([][]byte{e.vps, e.sps, e.pps}, au...)
+	}
+
+	if e.dtsExtractor == nil {
+		// skip samples silently until we find one with a IDR
+		if !isRandomAccess {
+			return nil
+		}
+		e.dtsExtractor = h265.NewDTSExtractor2()
+	}
+
+	dts, err := e.dtsExtractor.Extract(au, pts)
+	if err != nil {
+		e.logger.Errorf("error extracting dts: %s", err)
+		return nil
+	}
+
+	// h265 uses the same annexb format as h264
+	nalu, err := h264.AnnexBMarshal(au)
+	if err != nil {
+		e.logger.Errorf("failed to marshal annex b: %s", err)
+		return err
+	}
+	err = e.rawSeg.writePacket(nalu, pts, dts, isRandomAccess) //WritePacket(nalu, pts, dts, isRandomAccess)
+	if err != nil {
+		e.logger.Errorf("error writing packet to segmenter: %s", err)
+	}
+	return nil
+}
+
+func (e *rawSegmenterMux) writeH264(au [][]byte, pts int64) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	var filteredAU [][]byte
+	nonIDRPresent := false
+	idrPresent := false
+
+	for _, nalu := range au {
+		//nolint:mnd
+		typ := h264.NALUType(nalu[0] & 0x1F)
+		switch typ {
+		case h264.NALUTypeSPS:
+			e.sps = nalu
+			e.spsUnChanged = false
+			continue
+
+		case h264.NALUTypePPS:
+			e.pps = nalu
+			continue
+
+		case h264.NALUTypeAccessUnitDelimiter:
+			continue
+
+		case h264.NALUTypeIDR:
+			idrPresent = true
+
+		case h264.NALUTypeNonIDR:
+			nonIDRPresent = true
+		case h264.NALUTypeDataPartitionA,
+			h264.NALUTypeDataPartitionB,
+			h264.NALUTypeDataPartitionC,
+			h264.NALUTypeSEI,
+			h264.NALUTypeEndOfSequence,
+			h264.NALUTypeEndOfStream,
+			h264.NALUTypeFillerData,
+			h264.NALUTypeSPSExtension,
+			h264.NALUTypePrefix,
+			h264.NALUTypeSubsetSPS,
+			h264.NALUTypeReserved16,
+			h264.NALUTypeReserved17,
+			h264.NALUTypeReserved18,
+			h264.NALUTypeSliceLayerWithoutPartitioning,
+			h264.NALUTypeSliceExtension,
+			h264.NALUTypeSliceExtensionDepth,
+			h264.NALUTypeReserved22,
+			h264.NALUTypeReserved23,
+			h264.NALUTypeSTAPA,
+			h264.NALUTypeSTAPB,
+			h264.NALUTypeMTAP16,
+			h264.NALUTypeMTAP24,
+			h264.NALUTypeFUA,
+			h264.NALUTypeFUB:
+		default:
+			return errors.New("invalid nalu")
+		}
+
+		filteredAU = append(filteredAU, nalu)
+	}
+
+	au = filteredAU
+
+	if au == nil || (!nonIDRPresent && !idrPresent) {
+		return nil
+	}
+
+	if err := e.maybeReInitVideoStore(); err != nil {
+		e.logger.Debugf("unable to init video store: %s", err.Error())
+		return nil
+	}
+
+	// add SPS and PPS before access unit that contains an IDR
+	if idrPresent {
+		au = append([][]byte{e.sps, e.pps}, au...)
+	}
+
+	if e.dtsExtractor == nil {
+		// skip samples silently until we find one with a IDR
+		if !idrPresent {
+			return nil
+		}
+		e.dtsExtractor = h264.NewDTSExtractor2()
+	}
+
+	dts, err := e.dtsExtractor.Extract(au, pts)
+	if err != nil {
+		return nil
+	}
+
+	packed, err := h264.AnnexBMarshal(au)
+	if err != nil {
+		e.logger.Errorf("AnnexBMarshal err: %s", err.Error())
+		return err
+	}
+	err = e.rawSeg.writePacket(packed, pts, dts, idrPresent)
+	if err != nil {
+		e.logger.Errorf("error writing packet to segmenter: %s", err)
+	}
+	return nil
+}
+
+// // maybeReInitVideoStore assumes mu is held by caller.
+func (e *rawSegmenterMux) maybeReInitVideoStore() error {
+	if e.spsUnChanged {
+		return nil
+	}
+	var width, height int
+	switch e.codec {
+	case CodecTypeH265:
+		var hsps h265.SPS
+		if err := hsps.Unmarshal(e.sps); err != nil {
+			return err
+		}
+		width, height = hsps.Width(), hsps.Height()
+	case CodecTypeH264:
+		var hsps h264.SPS
+		if err := hsps.Unmarshal(e.sps); err != nil {
+			return err
+		}
+		width, height = hsps.Width(), hsps.Height()
+	default:
+		return errors.New("invalid videostore.CodecType")
+	}
+
+	if width <= 0 || height <= 0 {
+		return errors.New("width and height must both be greater than 0")
+	}
+	// if vs is initialized and the height & width have not changed,
+	// record the sps as unchanged and return
+	if e.rawSeg != nil && e.width == width && e.height == height {
+		e.spsUnChanged = true
+		return nil
+	}
+
+	// if initialized and the height & width have changed,
+	// close and nil out the videostore
+	if err := e.rawSeg.close(); err != nil {
+		return err
+	}
+
+	if err := e.rawSeg.init(e.codec, width, height); err != nil {
+		return err
+	}
+
+	e.width = width
+	e.height = height
+	e.spsUnChanged = true
+	return nil
+}
+
+func (e *rawSegmenterMux) close() error {
+	if err := e.rawSeg.close(); err != nil {
+		return err
+	}
+	e.codec = CodecTypeUnknown
+	e.width = 0
+	e.height = 0
+	e.vps = nil
+	e.sps = nil
+	e.pps = nil
+	e.dtsExtractor = nil
+	e.spsUnChanged = false
+	return nil
 }

--- a/videostore/videostore.go
+++ b/videostore/videostore.go
@@ -65,11 +65,9 @@ type videostore struct {
 	latestFrame atomic.Pointer[C.AVFrame]
 	workers     *utils.StoppableWorkers
 
-	// rawSegmenter *rawSegmenter
-	rawSeg *rawSegmenter
-	// videoStoreMuxer *rawSegmenterMux
-	segmenter *segmenter
-	concater  *concater
+	rawSegmenter *rawSegmenter
+	segmenter    *segmenter
+	concater     *concater
 }
 
 // VideoStore stores video and provides APIs to request the stored video
@@ -276,12 +274,12 @@ func NewRTPVideoStore(config Config, logger logging.Logger) (RTPVideoStore, erro
 	}
 
 	vs := &videostore{
-		typ:      config.Type,
-		concater: concater,
-		rawSeg:   rawSegmenter,
-		logger:   logger,
-		config:   config,
-		workers:  utils.NewBackgroundStoppableWorkers(),
+		typ:          config.Type,
+		concater:     concater,
+		rawSegmenter: rawSegmenter,
+		logger:       logger,
+		config:       config,
+		workers:      utils.NewBackgroundStoppableWorkers(),
 	}
 
 	vs.workers.Add(vs.deleter)
@@ -289,7 +287,7 @@ func NewRTPVideoStore(config Config, logger logging.Logger) (RTPVideoStore, erro
 }
 
 func (vs *videostore) Segmenter() *rawSegmenter {
-	return vs.rawSeg
+	return vs.rawSegmenter
 }
 
 func (vs *videostore) Fetch(_ context.Context, r *FetchRequest) (*FetchResponse, error) {
@@ -555,7 +553,7 @@ func (vs *videostore) Close() {
 	if vs.segmenter != nil {
 		vs.segmenter.close()
 	}
-	if vs.rawSeg != nil {
-		vs.rawSeg.Close()
+	if vs.rawSegmenter != nil {
+		vs.rawSegmenter.Close()
 	}
 }

--- a/videostore/videostore.go
+++ b/videostore/videostore.go
@@ -65,7 +65,7 @@ type videostore struct {
 	latestFrame atomic.Pointer[C.AVFrame]
 	workers     *utils.StoppableWorkers
 
-	rawSegmenter *rawSegmenter
+	rawSegmenter *RawSegmenter
 	segmenter    *segmenter
 	concater     *concater
 }
@@ -105,7 +105,7 @@ func (t CodecType) String() string {
 // RTPVideoStore stores video derived from RTP packets and provides APIs to request the stored video
 type RTPVideoStore interface {
 	VideoStore
-	Segmenter() *rawSegmenter
+	Segmenter() *RawSegmenter
 }
 
 // SaveRequest is the request to the Save method
@@ -286,7 +286,7 @@ func NewRTPVideoStore(config Config, logger logging.Logger) (RTPVideoStore, erro
 	return vs, nil
 }
 
-func (vs *videostore) Segmenter() *rawSegmenter {
+func (vs *videostore) Segmenter() *RawSegmenter {
 	return vs.rawSegmenter
 }
 


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-10002)

1. Change rawsegementer to support closing and initializing multiple times.
2. Document the rawsegementer state machine
3. Make *RawSegmenter and it's methods public so they can be used by viamrtsp
4. Upgrade github.com/bluenviron/mediacommon from[ v1.9.2 to v1.13.3](https://github.com/bluenviron/mediacommon/compare/v1.9.2...v1.13.3) to make it the same as viamrtsp
5. unify `config.SourceTypeH264RTPPacket` and `config.SourceTypeH265RTPPacket`  into `config.SourceTypeRTP`
6. Create `config.SourceTypeReadOnly` so that viamrtsp hosted video-store can support `DoCommand(fetch) and DoCommand(save)` even when there is no camera configured.
7. move `cleanupStorage` into videostore.go rather than being duplicated on the 2 segmenters.
8. Change `RTPVideoStore` to be a `VideoStore` with a `Segmenter() *rawSegmenter` method. This was needed as previously the segmenter and the `VideoStore` had to be the same object from viamrtsp's perspective which made the videostore implement a bunch of methods that couldn't be implemented in other cases (such as for the frame segmenter and when it is read only).
9. Validate the save request in the Save method (which I forgot to do in a previous PR)