### PR TITLE
[RSDK-10224] - Delete concated file during fetch

### DIFF
--- a/tests/fetch_test.go
+++ b/tests/fetch_test.go
@@ -12,12 +12,12 @@ import (
 	"go.viam.com/test"
 )
 
-// pathForFetchCmd constructs the .mp4 path based on the "from" field in the command
-func pathForFetchCmd(prefix string, cmd map[string]interface{}) string {
-	return "/tmp/" + prefix + "_" + cmd["from"].(string) + ".mp4"
+// pathForFetchCmd constructs the .mp4 path based on the "from" field in the command.
+func pathForFetchCmd(cmd map[string]interface{}) string {
+	return "/tmp/" + videoStoreComponentName + "_" + cmd["from"].(string) + ".mp4"
 }
 
-// assertNoFile checks that the given file path does NOT exist
+// assertNoFile checks that the given file path does NOT exist.
 func assertNoFile(t *testing.T, filePath string) {
 	_, err := os.Stat(filePath)
 	test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
@@ -132,7 +132,7 @@ func TestFetchDoCommand(t *testing.T) {
 		video, ok := res["video"].(string)
 		test.That(t, ok, test.ShouldBeTrue)
 		test.That(t, video, test.ShouldNotBeEmpty)
-		filePath := pathForFetchCmd(videoStoreComponentName, fetchCmd1)
+		filePath := pathForFetchCmd(fetchCmd1)
 		assertNoFile(t, filePath)
 	})
 
@@ -147,7 +147,7 @@ func TestFetchDoCommand(t *testing.T) {
 		_, err = vs.DoCommand(timeoutCtx, fetchCmd2)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "grpc")
-		filePath := pathForFetchCmd(videoStoreComponentName, fetchCmd2)
+		filePath := pathForFetchCmd(fetchCmd2)
 		assertNoFile(t, filePath)
 	})
 
@@ -162,7 +162,7 @@ func TestFetchDoCommand(t *testing.T) {
 		_, err = vs.DoCommand(timeoutCtx, fetchCmd3)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "range")
-		filePath := pathForFetchCmd(videoStoreComponentName, fetchCmd3)
+		filePath := pathForFetchCmd(fetchCmd3)
 		assertNoFile(t, filePath)
 	})
 
@@ -177,7 +177,7 @@ func TestFetchDoCommand(t *testing.T) {
 		_, err = vs.DoCommand(timeoutCtx, fetchCmd4)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "parsing time")
-		filePath := pathForFetchCmd(videoStoreComponentName, fetchCmd4)
+		filePath := pathForFetchCmd(fetchCmd4)
 		assertNoFile(t, filePath)
 	})
 }

--- a/tests/fetch_test.go
+++ b/tests/fetch_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 // pathForFetchCmd constructs the .mp4 path based on the "from" field in the command.
-func pathForFetchCmd(cmd map[string]interface{}) string {
-	return "/tmp/" + videoStoreComponentName + "_" + cmd["from"].(string) + ".mp4"
+func pathForFetchCmd(fromTimestamp string) string {
+	return "/tmp/" + videoStoreComponentName + "_" + fromTimestamp + ".mp4"
 }
 
 // assertNoFile checks that the given file path does NOT exist.
@@ -132,7 +132,7 @@ func TestFetchDoCommand(t *testing.T) {
 		video, ok := res["video"].(string)
 		test.That(t, ok, test.ShouldBeTrue)
 		test.That(t, video, test.ShouldNotBeEmpty)
-		filePath := pathForFetchCmd(fetchCmd1)
+		filePath := pathForFetchCmd(fetchCmd1["from"].(string))
 		assertNoFile(t, filePath)
 	})
 
@@ -147,7 +147,7 @@ func TestFetchDoCommand(t *testing.T) {
 		_, err = vs.DoCommand(timeoutCtx, fetchCmd2)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "grpc")
-		filePath := pathForFetchCmd(fetchCmd2)
+		filePath := pathForFetchCmd(fetchCmd2["from"].(string))
 		assertNoFile(t, filePath)
 	})
 
@@ -162,7 +162,7 @@ func TestFetchDoCommand(t *testing.T) {
 		_, err = vs.DoCommand(timeoutCtx, fetchCmd3)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "range")
-		filePath := pathForFetchCmd(fetchCmd3)
+		filePath := pathForFetchCmd(fetchCmd3["from"].(string))
 		assertNoFile(t, filePath)
 	})
 
@@ -177,7 +177,7 @@ func TestFetchDoCommand(t *testing.T) {
 		_, err = vs.DoCommand(timeoutCtx, fetchCmd4)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "parsing time")
-		filePath := pathForFetchCmd(fetchCmd4)
+		filePath := pathForFetchCmd(fetchCmd4["from"].(string))
 		assertNoFile(t, filePath)
 	})
 }

--- a/tests/fetch_test.go
+++ b/tests/fetch_test.go
@@ -3,6 +3,7 @@ package videostore_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -120,6 +121,9 @@ func TestFetchDoCommand(t *testing.T) {
 		video, ok := res["video"].(string)
 		test.That(t, ok, test.ShouldBeTrue)
 		test.That(t, video, test.ShouldNotBeEmpty)
+		path := "/tmp/" + videoStoreComponentName + "_" + fetchCmd1["from"].(string) + ".mp4"
+		_, err = os.Stat(path)
+		test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
 	})
 
 	t.Run("Test Fetch DoCommand Valid Time Range Over GRPC Limit.", func(t *testing.T) {
@@ -133,6 +137,9 @@ func TestFetchDoCommand(t *testing.T) {
 		_, err = vs.DoCommand(timeoutCtx, fetchCmd2)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "grpc")
+		path := "/tmp/" + videoStoreComponentName + "_" + fetchCmd2["from"].(string) + ".mp4"
+		_, err = os.Stat(path)
+		test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
 	})
 
 	t.Run("Test Fetch DoCommand Invalid Time Range.", func(t *testing.T) {
@@ -146,6 +153,9 @@ func TestFetchDoCommand(t *testing.T) {
 		_, err = vs.DoCommand(timeoutCtx, fetchCmd3)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "range")
+		path := "/tmp/" + videoStoreComponentName + "_" + fetchCmd3["from"].(string) + ".mp4"
+		_, err = os.Stat(path)
+		test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
 	})
 
 	t.Run("Test Fetch DoCommand Invalid Datetime Format.", func(t *testing.T) {
@@ -159,5 +169,8 @@ func TestFetchDoCommand(t *testing.T) {
 		_, err = vs.DoCommand(timeoutCtx, fetchCmd4)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "parsing time")
+		path := "/tmp/" + videoStoreComponentName + "_" + fetchCmd4["from"].(string) + ".mp4"
+		_, err = os.Stat(path)
+		test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
 	})
 }

--- a/tests/fetch_test.go
+++ b/tests/fetch_test.go
@@ -18,6 +18,7 @@ func pathForFetchCmd(fromTimestamp string) string {
 }
 
 // assertNoFile checks that the given file path does NOT exist.
+// used for testing that the temporary files created by fetch are being properly removed.
 func assertNoFile(t *testing.T, filePath string) {
 	_, err := os.Stat(filePath)
 	test.That(t, os.IsNotExist(err), test.ShouldBeTrue)

--- a/tests/fetch_test.go
+++ b/tests/fetch_test.go
@@ -12,6 +12,17 @@ import (
 	"go.viam.com/test"
 )
 
+// pathForFetchCmd constructs the .mp4 path based on the "from" field in the command
+func pathForFetchCmd(prefix string, cmd map[string]interface{}) string {
+	return "/tmp/" + prefix + "_" + cmd["from"].(string) + ".mp4"
+}
+
+// assertNoFile checks that the given file path does NOT exist
+func assertNoFile(t *testing.T, filePath string) {
+	_, err := os.Stat(filePath)
+	test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+}
+
 func TestFetchDoCommand(t *testing.T) {
 	storagePath, err := filepath.Abs(artifactStoragePath)
 	test.That(t, err, test.ShouldBeNil)
@@ -121,9 +132,8 @@ func TestFetchDoCommand(t *testing.T) {
 		video, ok := res["video"].(string)
 		test.That(t, ok, test.ShouldBeTrue)
 		test.That(t, video, test.ShouldNotBeEmpty)
-		path := "/tmp/" + videoStoreComponentName + "_" + fetchCmd1["from"].(string) + ".mp4"
-		_, err = os.Stat(path)
-		test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+		filePath := pathForFetchCmd(videoStoreComponentName, fetchCmd1)
+		assertNoFile(t, filePath)
 	})
 
 	t.Run("Test Fetch DoCommand Valid Time Range Over GRPC Limit.", func(t *testing.T) {
@@ -137,9 +147,8 @@ func TestFetchDoCommand(t *testing.T) {
 		_, err = vs.DoCommand(timeoutCtx, fetchCmd2)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "grpc")
-		path := "/tmp/" + videoStoreComponentName + "_" + fetchCmd2["from"].(string) + ".mp4"
-		_, err = os.Stat(path)
-		test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+		filePath := pathForFetchCmd(videoStoreComponentName, fetchCmd2)
+		assertNoFile(t, filePath)
 	})
 
 	t.Run("Test Fetch DoCommand Invalid Time Range.", func(t *testing.T) {
@@ -153,9 +162,8 @@ func TestFetchDoCommand(t *testing.T) {
 		_, err = vs.DoCommand(timeoutCtx, fetchCmd3)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "range")
-		path := "/tmp/" + videoStoreComponentName + "_" + fetchCmd3["from"].(string) + ".mp4"
-		_, err = os.Stat(path)
-		test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+		filePath := pathForFetchCmd(videoStoreComponentName, fetchCmd3)
+		assertNoFile(t, filePath)
 	})
 
 	t.Run("Test Fetch DoCommand Invalid Datetime Format.", func(t *testing.T) {
@@ -169,8 +177,7 @@ func TestFetchDoCommand(t *testing.T) {
 		_, err = vs.DoCommand(timeoutCtx, fetchCmd4)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "parsing time")
-		path := "/tmp/" + videoStoreComponentName + "_" + fetchCmd4["from"].(string) + ".mp4"
-		_, err = os.Stat(path)
-		test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+		filePath := pathForFetchCmd(videoStoreComponentName, fetchCmd4)
+		assertNoFile(t, filePath)
 	})
 }

--- a/videostore/concat.c
+++ b/videostore/concat.c
@@ -131,7 +131,7 @@ int video_store_concat(const char *concat_filepath, const char *output_path) {
 
     if (packet->dts <= prevDts) {
       av_log(NULL, AV_LOG_DEBUG,
-             "video_store_concat skipping non monotonically increaseing dts: "
+             "video_store_concat skipping non monotonically increasing dts: "
              "%ld, prevDts: %ld\n",
              packet->dts, prevDts);
       av_packet_unref(packet);

--- a/videostore/videostore.go
+++ b/videostore/videostore.go
@@ -303,8 +303,8 @@ func (vs *videostore) Fetch(_ context.Context, r *FetchRequest) (*FetchResponse,
 		tempPath)
 
 	// Always attempt to remove the concat file after the operation.
-	// This handles error cases in Concat where the file fails in the
-	// middle of writing.
+	// This handles error cases in Concat where it fails in the middle
+	// of writing.
 	defer func() {
 		if err := os.Remove(fetchFilePath); err != nil {
 			vs.logger.Debug("failed to delete temporary file", err)

--- a/videostore/videostore.go
+++ b/videostore/videostore.go
@@ -306,8 +306,12 @@ func (vs *videostore) Fetch(_ context.Context, r *FetchRequest) (*FetchResponse,
 	// This handles error cases in Concat where it fails in the middle
 	// of writing.
 	defer func() {
+		if _, statErr := os.Stat(fetchFilePath); os.IsNotExist(statErr) {
+			vs.logger.Debugf("temporary file (%s) does not exist, skipping removal", fetchFilePath)
+			return
+		}
 		if err := os.Remove(fetchFilePath); err != nil {
-			vs.logger.Debugf("failed to delete temporary file (%s): %v", fetchFilePath, err)
+			vs.logger.Warnf("failed to delete temporary file (%s): %v", fetchFilePath, err)
 		}
 	}()
 	if err := vs.concater.Concat(r.From, r.To, fetchFilePath); err != nil {

--- a/videostore/videostore.go
+++ b/videostore/videostore.go
@@ -296,7 +296,6 @@ func (vs *videostore) Fetch(_ context.Context, r *FetchRequest) (*FetchResponse,
 		return nil, err
 	}
 	vs.logger.Debug("fetch command received")
-
 	fetchFilePath := generateOutputFilePath(
 		vs.config.Storage.OutputFileNamePrefix,
 		formatDateTimeToString(r.From),
@@ -310,6 +309,9 @@ func (vs *videostore) Fetch(_ context.Context, r *FetchRequest) (*FetchResponse,
 	videoBytes, err := readVideoFile(fetchFilePath)
 	if err != nil {
 		return nil, err
+	}
+	if err := os.Remove(fetchFilePath); err != nil {
+		vs.logger.Error("failed to delete temporary file", err)
 	}
 	return &FetchResponse{Video: videoBytes}, nil
 }

--- a/videostore/videostore.go
+++ b/videostore/videostore.go
@@ -307,7 +307,7 @@ func (vs *videostore) Fetch(_ context.Context, r *FetchRequest) (*FetchResponse,
 	// of writing.
 	defer func() {
 		if err := os.Remove(fetchFilePath); err != nil {
-			vs.logger.Debug("failed to delete temporary file", err)
+			vs.logger.Debugf("failed to delete temporary file (%s): %v", fetchFilePath, err)
 		}
 	}()
 	if err := vs.concater.Concat(r.From, r.To, fetchFilePath); err != nil {


### PR DESCRIPTION
## Description

Simply deleting file in fetch after it is read into go bytes.


## Testing

If we comment out file removal from fetch flow, the success fetch test case will fail with a leftover file.