### PR TITLE
[RSDK-10223] -   Return an error if async save command's `to` field is in the future

### DIFF
--- a/tests/save_test.go
+++ b/tests/save_test.go
@@ -117,7 +117,7 @@ func TestSaveDoCommand(t *testing.T) {
 	saveCmd5 := map[string]interface{}{
 		"command":  "save",
 		"from":     "2024-09-06_15-00-33",
-		"to":       "2025-09-06_15-00-33",
+		"to":       "3024-09-06_15-00-33",
 		"metadata": "test-metadata",
 		"async":    true,
 	}

--- a/videostore/videostore.go
+++ b/videostore/videostore.go
@@ -102,7 +102,7 @@ func (r *SaveRequest) Validate() error {
 	if r.From.After(r.To) {
 		return errors.New("'from' timestamp is after 'to' timestamp")
 	}
-	if r.Async && r.To.After(time.Now()) {
+	if r.To.After(time.Now()) {
 		return errors.New("'to' timestamp is in the future")
 	}
 	return nil
@@ -296,6 +296,9 @@ func (vs *videostore) Fetch(_ context.Context, r *FetchRequest) (*FetchResponse,
 
 func (vs *videostore) Save(_ context.Context, r *SaveRequest) (*SaveResponse, error) {
 	vs.logger.Debug("save command received")
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
 	uploadFilePath := generateOutputFilePath(
 		vs.config.Storage.OutputFileNamePrefix,
 		formatDateTimeToString(r.From),
@@ -339,7 +342,7 @@ func (vs *videostore) fetchFrames(ctx context.Context, cam camera.Camera) {
 			}
 			bytes, metadata, err := cam.Image(ctx, mimeTypeReq, nil)
 			if err != nil {
-				vs.logger.Warn("failed to get frame from camera", err)
+				vs.logger.Warn("failed to get frame from camera: ", err)
 				time.Sleep(retryInterval * time.Second)
 				continue
 			}
@@ -353,13 +356,13 @@ func (vs *videostore) fetchFrames(ctx context.Context, cam camera.Camera) {
 				case mimeTypeYUYV:
 					frame, err = mimeHandler.yuyvToYUV420p(bytes)
 					if err != nil {
-						vs.logger.Error("failed to convert yuyv422 to yuv420p", err)
+						vs.logger.Error("failed to convert yuyv422 to yuv420p: ", err)
 						return
 					}
 				case rutils.MimeTypeJPEG, rutils.MimeTypeJPEG + "+" + rutils.MimeTypeSuffixLazy:
 					frame, err = mimeHandler.decodeJPEG(bytes)
 					if err != nil {
-						vs.logger.Error("failed to decode jpeg", err)
+						vs.logger.Error("failed to decode jpeg: ", err)
 						return
 					}
 				default:

--- a/videostore/videostore.go
+++ b/videostore/videostore.go
@@ -102,6 +102,9 @@ func (r *SaveRequest) Validate() error {
 	if r.From.After(r.To) {
 		return errors.New("'from' timestamp is after 'to' timestamp")
 	}
+	if r.Async && r.To.After(time.Now()) {
+		return errors.New("'to' timestamp is in the future")
+	}
 	return nil
 }
 


### PR DESCRIPTION
[RSDK-10223](https://viam.atlassian.net/browse/RSDK-10223)

[RSDK-10223]: https://viam.atlassian.net/browse/RSDK-10223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Manual Tests
Before PR (off registry)
![Screenshot 2025-03-13 at 2 40 15 PM](https://github.com/user-attachments/assets/1d0b2913-5543-4907-960d-ea32b2b5f81e)

After PR (local build off feature branch)
![Screenshot 2025-03-13 at 3 09 55 PM](https://github.com/user-attachments/assets/cfe20124-7174-40cf-8eec-01c4f855df86)
