### PR TITLE
[RSDK-10486]   Support querying videos in UTC time

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,18 +101,24 @@ The `From` and `To` timestamps are used to specify the start and end times for v
 
 #### Datetime Format
 
-The datetime format used is: `YYYY-MM-DD_HH-MM-SS`
+The datetime format used is:
 
+- Local Time: `YYYY-MM-DD_HH-MM-SS`
+- UTC Time: `YYYY-MM-DD_HH-MM-SSZ`
+
+Where:
 - `YYYY`: Year (e.g., 2023)
 - `MM`: Month (e.g., 01 for January)
 - `DD`: Day (e.g., 15)
 - `HH`: Hour in 24-hour format (e.g., 14 for 2 PM)
 - `MM`: Minutes (e.g., 30)
 - `SS`: Seconds (e.g., 45)
+- `Z`: Optional suffix indicating the time is in UTC.
 
 #### Datetime Example
 
-- `2024-01-15_14-30-45` represents January 15, 2024, at 2:30:45 PM.
+- `2024-01-15_14-30-45` represents January 15, 2024, at 2:30:45 PM **local time**.
+- `2024-01-15_14-30-45Z` represents January 15, 2024, at 2:30:45 PM **UTC**.
 
 ### `Save`
 

--- a/tests/fetch_test.go
+++ b/tests/fetch_test.go
@@ -145,6 +145,21 @@ func TestFetchDoCommand(t *testing.T) {
 		assertNoFile(t, filePath)
 	})
 
+	t.Run("Test Fetch DoCommand Valid Time Range Over GRPC Limit.", func(t *testing.T) {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		r, err := setupViamServer(timeoutCtx, config1)
+		test.That(t, err, test.ShouldBeNil)
+		defer r.Close(timeoutCtx)
+		vs, err := camera.FromRobot(r, videoStoreComponentName)
+		test.That(t, err, test.ShouldBeNil)
+		_, err = vs.DoCommand(timeoutCtx, fetchCmd2)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "grpc")
+		filePath := pathForFetchCmd(fetchCmd2["from"].(string))
+		assertNoFile(t, filePath)
+	})
+
 	t.Run("Test Fetch DoCommand Valid UTC Time Range Under GRPC Limit.", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
@@ -159,21 +174,6 @@ func TestFetchDoCommand(t *testing.T) {
 		test.That(t, ok, test.ShouldBeTrue)
 		test.That(t, video, test.ShouldNotBeEmpty)
 		filePath := pathForFetchCmd(fetchCmdUTC["from"].(string))
-		assertNoFile(t, filePath)
-	})
-
-	t.Run("Test Fetch DoCommand Valid Time Range Over GRPC Limit.", func(t *testing.T) {
-		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
-		defer cancel()
-		r, err := setupViamServer(timeoutCtx, config1)
-		test.That(t, err, test.ShouldBeNil)
-		defer r.Close(timeoutCtx)
-		vs, err := camera.FromRobot(r, videoStoreComponentName)
-		test.That(t, err, test.ShouldBeNil)
-		_, err = vs.DoCommand(timeoutCtx, fetchCmd2)
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "grpc")
-		filePath := pathForFetchCmd(fetchCmd2["from"].(string))
 		assertNoFile(t, filePath)
 	})
 

--- a/tests/save_test.go
+++ b/tests/save_test.go
@@ -22,6 +22,8 @@ const (
 	invalidFromTimestamp       = "2024-09-06_14-00-03"
 	invalidToTimestamp         = "3024-09-06_15-00-33"
 	invalidDatetimeFormat      = "2024/09/06 15:01:33"
+	validFromTimestampUTC      = "2024-09-06_15-00-33Z"
+	validToTimestampUTC        = "2024-09-06_15-01-33Z"
 )
 
 func TestSaveDoCommand(t *testing.T) {
@@ -133,6 +135,23 @@ func TestSaveDoCommand(t *testing.T) {
 		"async":    true,
 	}
 
+	// Valid UTC time range
+	saveCmdUTC := map[string]interface{}{
+		"command":  "save",
+		"from":     validFromTimestampUTC,
+		"to":       validToTimestampUTC,
+		"metadata": "test-metadata-utc",
+	}
+
+	// Valid async UTC save
+	saveCmdAsyncUTC := map[string]interface{}{
+		"command":  "save",
+		"from":     validFromTimestampUTC,
+		"to":       validToTimestampUTC,
+		"metadata": "test-metadata-async-utc",
+		"async":    true,
+	}
+
 	t.Run("Test Save DoCommand Valid Range", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
@@ -212,6 +231,77 @@ func TestSaveDoCommand(t *testing.T) {
 		_, err = vs.DoCommand(timeoutCtx, saveCmd5)
 		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, err.Error(), test.ShouldContainSubstring, "'to' timestamp is in the future")
+	})
+
+	t.Run("Test Save DoCommand Valid UTC Range", func(t *testing.T) {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		r, err := setupViamServer(timeoutCtx, config1)
+		test.That(t, err, test.ShouldBeNil)
+		defer r.Close(timeoutCtx)
+		vs, err := camera.FromRobot(r, videoStoreComponentName)
+		test.That(t, err, test.ShouldBeNil)
+		res, err := vs.DoCommand(timeoutCtx, saveCmdUTC)
+		test.That(t, err, test.ShouldBeNil)
+		filename, ok := res["filename"].(string)
+		test.That(t, ok, test.ShouldBeTrue)
+
+		// Calculate expected timestamp from fromTime (parsed as UTC, converted to local for filename)
+		fromTimeUTC, err := time.Parse(videostore.TimeFormat, "2024-09-06_15-00-33") // Parse without Z
+		test.That(t, err, test.ShouldBeNil)
+		fromTimeLocal := fromTimeUTC.Local() // Convert to local time for filename generation
+		expectedFilename := fmt.Sprintf("%s_%s_%s.mp4",
+			videoStoreComponentName,
+			fromTimeLocal.Format(videostore.TimeFormat),
+			"test-metadata-utc")
+		test.That(t, filename, test.ShouldEqual, expectedFilename)
+		test.That(t, filename, test.ShouldContainSubstring, "test-metadata-utc")
+
+		filePath := filepath.Join(testUploadPath, filename)
+		testVideoPlayback(t, filePath)
+		testVideoDuration(t, filePath, 60)
+	})
+
+	t.Run("Test Save DoCommand Async UTC", func(t *testing.T) {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		r, err := setupViamServer(timeoutCtx, config1)
+		test.That(t, err, test.ShouldBeNil)
+		defer r.Close(timeoutCtx)
+		vs, err := camera.FromRobot(r, videoStoreComponentName)
+		test.That(t, err, test.ShouldBeNil)
+		res, err := vs.DoCommand(timeoutCtx, saveCmdAsyncUTC)
+		test.That(t, err, test.ShouldBeNil)
+		filename, ok := res["filename"].(string)
+		test.That(t, ok, test.ShouldBeTrue)
+		status, ok := res["status"].(string)
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, status, test.ShouldEqual, "async")
+
+		// Wait for async save to potentially complete (best effort check)
+		time.Sleep(35 * time.Second)
+
+		// Calculate expected timestamp from fromTime (parsed as UTC, converted to local for filename)
+		fromTimeUTC, err := time.Parse(videostore.TimeFormat, "2024-09-06_15-00-33") // Parse without Z
+		test.That(t, err, test.ShouldBeNil)
+		fromTimeLocal := fromTimeUTC.Local() // Convert to local time for filename generation
+		expectedFilename := fmt.Sprintf("%s_%s_%s.mp4",
+			videoStoreComponentName,
+			fromTimeLocal.Format(videostore.TimeFormat),
+			"test-metadata-async-utc")
+		test.That(t, filename, test.ShouldEqual, expectedFilename)
+
+		// Check if file exists (best effort for async)
+		filePath := filepath.Join(testUploadPath, filename)
+		_, statErr := os.Stat(filePath)
+		if statErr == nil {
+			t.Logf("Async UTC save created file %s as expected", filename)
+			testVideoPlayback(t, filePath)
+		} else if os.IsNotExist(statErr) {
+			t.Logf("Async UTC save file %s not found after wait, might still be processing", filename)
+		} else {
+			t.Errorf("Error checking for async UTC save file %s: %v", filename, statErr)
+		}
 	})
 
 	t.Run("Test leftover concat txt files are cleaned up", func(t *testing.T) {

--- a/videostore/utils.go
+++ b/videostore/utils.go
@@ -248,7 +248,10 @@ func extractDateTimeFromFilename(filePath string) (time.Time, error) {
 // ParseDateTimeString parses a datetime string in our format (2006-01-02_15-04-05)
 // and returns it in local time.
 func ParseDateTimeString(datetime string) (time.Time, error) {
-	//nolint:gosmopolitan // datetime format timestamps must be parsed into local time
+	if strings.HasSuffix(datetime, "Z") {
+		return time.Parse(TimeFormat, strings.TrimSuffix(datetime, "Z"))
+	}
+	//nolint:gosmopolitan // intentional parsing into local time
 	return time.ParseInLocation(TimeFormat, datetime, time.Local)
 }
 

--- a/videostore/videostore.go
+++ b/videostore/videostore.go
@@ -25,10 +25,10 @@ const (
 	segmentSeconds = 30 // seconds
 	videoFormat    = "mp4"
 
-	deleterInterval       = 1  // minutes
-	retryInterval         = 1  // seconds
-	asyncTimeout          = 60 // seconds
-	tempPath              = "/tmp"
+	deleterInterval = 1  // minutes
+	retryInterval   = 1  // seconds
+	asyncTimeout    = 60 // seconds
+	tempPath        = "/tmp"
 
 	// TimeFormat is how we format the timestamp in output filenames and do commands.
 	TimeFormat = "2006-01-02_15-04-05"


### PR DESCRIPTION
[RSDK-10486](https://viam.atlassian.net/browse/RSDK-10486)

[RSDK-10486]: https://viam.atlassian.net/browse/RSDK-10486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

# Manual Tests
## Save cmd
```
{
        "command": "save",
        "from": "2025-04-18_14-32-02",
        "to": "2025-04-18_14-32-12",
        "metadata": "metadata",
        "async": false
}
```
vs.
```
{
        "command": "save",
        "from": "2025-04-18_18-32-03Z",
        "to": "2025-04-18_18-32-12Z",
        "metadata": "metadata",
        "async": false
}
```

Nice! Succeeded. Here are comparison videos from the two cmds

https://github.com/user-attachments/assets/6b74eb9f-9e6b-450c-8c6a-a960ba042c8a

https://github.com/user-attachments/assets/d5099227-0730-4a43-a891-0b64a4503b1b

## Fetch cmd
`go run ./examples/fetch/fetch_client.go vs-1 2025-04-18_18-32-03Z 2025-04-18_18-32-12Z`

Fetch also worked with the same time args

https://github.com/user-attachments/assets/557785d9-ef1e-4ec6-94e7-0f21b036dc94

