### PR TITLE
APP-15000 Direct upload via FileUpload API; Save command specify tags and datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ Additionally, make sure to add your configured data manager service to the `depe
 |                 | `size_gb`         | integer | yes  | Total amount of allocated storage in gigabytes. If you reduce the amound of allocated storage while the storage exceeds the allocated amount, the oldest clips get deleted until the storage size is below the configured max. |
 |                 | `storage_path`    | string  | no  | Custom path to use for video storage.                                                             |
 |                 | `upload_path`     | string  | no  | Custom path to use for uploading files. If not under `~/.viam/capture`, you will need to add to `additional_sync_paths` in datamanager service configuration. |
+| `direct_upload` |                   | object  | no  | When enabled, uploads saved clips directly to Viam App using DataSync `FileUpload` (avoids datamanager watched `upload_path`). |
+|                 | `enabled`         | boolean | no  | Enables direct upload. Default false.                                                             |
+|                 | `base_url`        | string  | no  | Viam App base URL. Default `https://app.viam.com`.                                                 |
+|                 | `staging_dir`     | string  | no  | Directory to write clips before uploading. Defaults to `<storage_path>/direct-upload-staging`.     |
+|                 | `delete_after_upload` | boolean | no | Delete staged file after successful upload. Default true.                                          |
+|                 | `default_tags`    | array[string] | no | Tags applied to every upload.                                                                      |
+|                 | `dataset_ids`     | array[string] | no | Dataset IDs applied to every upload.                                                               |
+|                 | `max_retries`     | integer | no  | Number of retries after the initial upload attempt. Default 3.                                     |
+|                 | `initial_retry_delay_ms` | integer | no | Delay before first retry; subsequent retries use exponential backoff. Default 1000.               |
 | `video`         |                   | object  | no  |                                                                                                   |
 |                 | `format`          | string  | no  | Name of video format to use (e.g., mp4).                                                          |
 |                 | `codec`           | string  | no  | Name of video codec to use (e.g., h264).                                                          |
@@ -131,6 +140,12 @@ The save command retreives video from local storage, concatenates and trims unde
 | `to`        | timestamp           | required          | End timestamp.                   |
 | `metadata`  | string              | optional          | Arbitrary metadata string.       |
 | `async`     | boolean             | optional          | Whether the operation is async.  |
+| `tags`      | array[string]       | optional          | Tags to apply to the uploaded file (**direct upload only**). |
+| `dataset_ids` | array[string]     | optional          | Dataset IDs to apply to the uploaded file (**direct upload only**). |
+
+> [!NOTE]
+> The `tags` and `dataset_ids` fields are only used when `direct_upload.enabled` is set in the component config.
+> When direct upload is disabled, the module uses the legacy datamanager `upload_path` behavior and these fields are ignored.
 
 ##### Save Request
 ```json
@@ -138,7 +153,9 @@ The save command retreives video from local storage, concatenates and trims unde
   "command": "save",
   "from": <start_timestamp>,
   "to": <end_timestamp>,
-  "metadata": <arbitrary_metadata_string>
+  "metadata": <arbitrary_metadata_string>,
+  "tags": ["tag1", "tag2"],
+  "dataset_ids": ["dataset-id-1", "dataset-id-2"]
 }
 ```
 
@@ -164,7 +181,9 @@ The async save command performs the same operation as the save command, but does
   "from": <start_timestamp>,
   "to": <end_timestamp>,
   "metadata": <arbitrary_metadata_string>,
-  "async": true
+  "async": true,
+  "tags": ["tag1", "tag2"],
+  "dataset_ids": ["dataset-id-1", "dataset-id-2"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Additionally, make sure to add your configured data manager service to the `depe
 |                 | `upload_path`     | string  | no  | Custom path to use for uploading files. If not under `~/.viam/capture`, you will need to add to `additional_sync_paths` in datamanager service configuration. |
 | `direct_upload` |                   | object  | no  | When enabled, uploads saved clips directly to Viam App using DataSync `FileUpload` (avoids datamanager watched `upload_path`). |
 |                 | `enabled`         | boolean | no  | Enables direct upload. Default false.                                                             |
-|                 | `base_url`        | string  | no  | Viam App base URL. Default `https://app.viam.com`.                                                 |
+|                 | `base_url`        | string  | no  | DataSync gRPC endpoint in the form `protocol://host:port`. Default `https://app.viam.com:443`.     |
 |                 | `staging_dir`     | string  | no  | Directory to write clips before uploading. Defaults to `<storage_path>/direct-upload-staging`.     |
 |                 | `delete_after_upload` | boolean | no | Delete staged file after successful upload. Default true.                                          |
 |                 | `default_tags`    | array[string] | no | Tags applied to every upload.                                                                      |

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/rhysd/actionlint v1.7.8
+	go.viam.com/api v0.1.487
 	go.viam.com/rdk v0.103.0
 	go.viam.com/test v1.2.4
 	go.viam.com/utils v0.3.1
@@ -202,7 +203,6 @@ require (
 	go.uber.org/goleak v1.3.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	go.viam.com/api v0.1.487 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2 // indirect
 	goji.io v2.0.2+incompatible // indirect

--- a/videostore/config.go
+++ b/videostore/config.go
@@ -87,7 +87,7 @@ func (c *Config) Validate() error {
 // then uploaded asynchronously using the DataSync FileUpload API.
 type DirectUploadConfig struct {
 	Enabled bool
-	// BaseURL is the API base URL. Defaults to https://app.viam.com.
+	// BaseURL is the Viam App gRPC endpoint. Defaults to https://app.viam.com:443.
 	BaseURL string
 	// StagingDir is the directory to write clips before uploading. Must not be a datamanager sync path.
 	// Defaults to <storage_path>/direct-upload-staging.

--- a/videostore/config.go
+++ b/videostore/config.go
@@ -106,6 +106,7 @@ type DirectUploadConfig struct {
 	InitialRetryDelayMillis int
 }
 
+// Validate returns an error if the DirectUploadConfig is invalid.
 func (c *DirectUploadConfig) Validate() error {
 	if c.MaxRetries < 0 {
 		return errors.New("direct upload max_retries can't be negative")

--- a/videostore/direct_upload.go
+++ b/videostore/direct_upload.go
@@ -1,0 +1,332 @@
+// This file implements optional "direct upload" behavior for videostore Save outputs.
+//
+// When enabled, videostore writes Save outputs to a staging directory (not a datamanager watched path),
+// then uploads the file asynchronously to Viam App using the DataSync FileUpload streaming RPC.
+//
+// The upload runs with a small bounded retry loop with exponential backoff and can optionally delete the staged file
+// after successful upload.
+package videostore
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	syncpb "go.viam.com/api/app/datasync/v1"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/utils"
+	"go.viam.com/utils/rpc"
+)
+
+const directUploadChunkSize = 64 * 1024
+
+type directUploader struct {
+	logger logging.Logger
+	cfg    *DirectUploadConfig
+
+	baseURL  string
+	partID   string
+	apiKey   string
+	apiKeyID string
+
+	mu     sync.Mutex
+	conn   rpc.ClientConn
+	client syncpb.DataSyncServiceClient
+}
+
+// newDirectUploader initializes a DataSync FileUpload client that authenticates via env-based API key credentials.
+func newDirectUploader(cfg *DirectUploadConfig, logger logging.Logger) (*directUploader, error) {
+	if cfg == nil || !cfg.Enabled {
+		return nil, nil
+	}
+
+	apiKey := os.Getenv(utils.APIKeyEnvVar)
+	apiKeyID := os.Getenv(utils.APIKeyIDEnvVar)
+	partID := os.Getenv(utils.MachinePartIDEnvVar)
+	if apiKey == "" || apiKeyID == "" || partID == "" {
+		return nil, fmt.Errorf(
+			"direct_upload enabled but missing env vars: %s, %s, and/or %s",
+			utils.APIKeyEnvVar,
+			utils.APIKeyIDEnvVar,
+			utils.MachinePartIDEnvVar,
+		)
+	}
+
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = "https://app.viam.com"
+	}
+
+	return &directUploader{
+		logger:   logger,
+		cfg:      cfg,
+		baseURL:  baseURL,
+		partID:   partID,
+		apiKey:   apiKey,
+		apiKeyID: apiKeyID,
+	}, nil
+}
+
+// Close closes any cached gRPC connection to Viam App.
+func (u *directUploader) Close() {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if u.conn != nil {
+		_ = u.conn.Close()
+		u.conn = nil
+		u.client = nil
+	}
+}
+
+func (u *directUploader) ensureClient(ctx context.Context) (syncpb.DataSyncServiceClient, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	if u.client != nil {
+		return u.client, nil
+	}
+
+	baseURL := u.baseURL
+	if !strings.HasPrefix(baseURL, "http://") && !strings.HasPrefix(baseURL, "https://") {
+		return nil, fmt.Errorf("direct upload base_url must start with http:// or https://, got %q", baseURL)
+	}
+	if !strings.HasSuffix(baseURL, ":443") {
+		baseURL += ":443"
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	creds := rpc.Credentials{
+		Type:    rpc.CredentialsTypeAPIKey,
+		Payload: u.apiKey,
+	}
+	dopt := rpc.WithEntityCredentials(u.apiKeyID, creds)
+	conn, err := rpc.DialDirectGRPC(ctx, parsed.Host, u.logger, dopt)
+	if err != nil {
+		return nil, err
+	}
+
+	u.conn = conn
+	u.client = syncpb.NewDataSyncServiceClient(conn)
+	return u.client, nil
+}
+
+// uploadFile performs a streaming DataSync FileUpload from disk with tags/datasetIDs applied in UploadMetadata.
+func (u *directUploader) uploadFile(
+	ctx context.Context,
+	filePath string,
+	tags []string,
+	datasetIDs []string,
+) (string, error) {
+	client, err := u.ensureClient(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	//nolint:gosec // filePath originates from internal staging dir.
+	f, err := os.Open(absPath)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+
+	stream, err := client.FileUpload(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	ext := filepath.Ext(absPath)
+	metaReq := &syncpb.FileUploadRequest{
+		UploadPacket: &syncpb.FileUploadRequest_Metadata{
+			Metadata: &syncpb.UploadMetadata{
+				PartId:        u.partID,
+				Type:          syncpb.DataType_DATA_TYPE_FILE,
+				FileName:      absPath,
+				FileExtension: ext,
+				Tags:          tags,
+				DatasetIds:    datasetIDs,
+			},
+		},
+	}
+	if err := stream.Send(metaReq); err != nil {
+		return "", err
+	}
+
+	buf := make([]byte, directUploadChunkSize)
+	for {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		n, rerr := f.Read(buf)
+		if n > 0 {
+			dataReq := &syncpb.FileUploadRequest{
+				UploadPacket: &syncpb.FileUploadRequest_FileContents{
+					FileContents: &syncpb.FileData{Data: buf[:n]},
+				},
+			}
+			if err := stream.Send(dataReq); err != nil {
+				return "", err
+			}
+		}
+		if rerr != nil {
+			if rerr == io.EOF {
+				break
+			}
+			return "", rerr
+		}
+	}
+
+	resp, err := stream.CloseAndRecv()
+	if err != nil {
+		return "", err
+	}
+	return resp.GetFileId(), nil
+}
+
+// maybeEnqueueDirectUpload schedules an asynchronous upload job for the given file path if direct upload is enabled.
+func (vs *videostore) maybeEnqueueDirectUpload(filePath string, r *SaveRequest) {
+	if vs.directUploader == nil || vs.config.DirectUpload == nil || !vs.config.DirectUpload.Enabled {
+		return
+	}
+
+	// Copy slices to avoid surprises if caller mutates.
+	reqTags := append([]string(nil), r.Tags...)
+	reqDatasets := append([]string(nil), r.DatasetIDs...)
+	metadata := r.Metadata
+
+	vs.workers.Add(func(ctx context.Context) {
+		tags := buildDirectUploadTags(vs.config.DirectUpload.DefaultTags, reqTags, metadata)
+		datasets := dedupeStrings(append(append([]string(nil), vs.config.DirectUpload.DatasetIDs...), reqDatasets...))
+
+		fileID, err := uploadWithRetry(
+			ctx,
+			vs.directUploader,
+			filePath,
+			tags,
+			datasets,
+			vs.config.DirectUpload.MaxRetries,
+			time.Duration(vs.config.DirectUpload.InitialRetryDelayMillis)*time.Millisecond,
+		)
+		if err != nil {
+			vs.logger.Errorw("direct upload failed", "file", filePath, "error", err)
+			return
+		}
+
+		vs.logger.Debugw("direct upload succeeded", "file", filePath, "file_id", fileID)
+		if vs.config.DirectUpload.DeleteAfterUpload == nil || *vs.config.DirectUpload.DeleteAfterUpload {
+			if err := os.Remove(filePath); err != nil && !os.IsNotExist(err) {
+				vs.logger.Warnw("failed deleting staged file after upload", "file", filePath, "error", err)
+			}
+		}
+	})
+}
+
+func uploadWithRetry(
+	ctx context.Context,
+	u *directUploader,
+	filePath string,
+	tags []string,
+	datasetIDs []string,
+	maxRetries int,
+	initialDelay time.Duration,
+) (string, error) {
+	var lastErr error
+	delay := initialDelay
+	attempts := maxRetries + 1 // include initial attempt
+	for i := 0; i < attempts; i++ {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		fileID, err := u.uploadFile(ctx, filePath, tags, datasetIDs)
+		if err == nil {
+			return fileID, nil
+		}
+		lastErr = err
+		if i == attempts-1 {
+			break
+		}
+		if delay <= 0 {
+			delay = time.Second
+		}
+		t := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			t.Stop()
+			return "", ctx.Err()
+		case <-t.C:
+		}
+		delay *= 2
+	}
+	return "", lastErr
+}
+
+func buildDirectUploadTags(defaultTags []string, requestTags []string, metadata string) []string {
+	tags := append([]string(nil), defaultTags...)
+	tags = append(tags, requestTags...)
+
+	if metadata != "" {
+		// Make metadata searchable without requiring client changes.
+		// Keep it stable + safe as a tag by sanitizing.
+		meta := sanitizeTagComponent(metadata)
+		if meta != "" {
+			tag := "videostore-metadata-" + meta
+			if len(tag) > 128 {
+				tag = tag[:128]
+			}
+			tags = append(tags, tag)
+		}
+	}
+
+	return dedupeStrings(tags)
+}
+
+func sanitizeTagComponent(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b.WriteRune(r)
+		case r == '-' || r == '_' || r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	return out
+}
+
+func dedupeStrings(in []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/videostore/direct_upload_test.go
+++ b/videostore/direct_upload_test.go
@@ -42,7 +42,7 @@ func (s *fakeDataSyncServer) FileUpload(stream syncpb.DataSyncService_FileUpload
 			}
 		}
 	}
-	return stream.SendAndClose(&syncpb.FileUploadResponse{FileId: "file-123"})
+	return stream.SendAndClose(&syncpb.FileUploadResponse{BinaryDataId: "file-123"})
 }
 
 func TestDirectUploaderFileUploadSendsMetadataAndChunks(t *testing.T) {

--- a/videostore/direct_upload_test.go
+++ b/videostore/direct_upload_test.go
@@ -33,7 +33,7 @@ func (s *fakeDataSyncServer) FileUpload(stream syncpb.DataSyncService_FileUpload
 			}
 			return err
 		}
-		switch pkt := req.UploadPacket.(type) {
+		switch pkt := req.GetUploadPacket().(type) {
 		case *syncpb.FileUploadRequest_Metadata:
 			s.gotMeta = pkt.Metadata
 		case *syncpb.FileUploadRequest_FileContents:
@@ -63,7 +63,7 @@ func TestDirectUploaderFileUploadSendsMetadataAndChunks(t *testing.T) {
 		logger,
 		rpc.WithDisableMulticastDNS(),
 		rpc.WithAuthHandler(rpc.CredentialsTypeAPIKey, rpc.AuthHandlerFunc(
-			func(ctx context.Context, entity, payload string) (map[string]string, error) {
+			func(_ context.Context, entity, payload string) (map[string]string, error) {
 				return map[string]string{}, nil
 			},
 		)),

--- a/videostore/direct_upload_test.go
+++ b/videostore/direct_upload_test.go
@@ -63,7 +63,7 @@ func TestDirectUploaderFileUploadSendsMetadataAndChunks(t *testing.T) {
 		logger,
 		rpc.WithDisableMulticastDNS(),
 		rpc.WithAuthHandler(rpc.CredentialsTypeAPIKey, rpc.AuthHandlerFunc(
-			func(_ context.Context, entity, payload string) (map[string]string, error) {
+			func(_ context.Context, _, _ string) (map[string]string, error) {
 				return map[string]string{}, nil
 			},
 		)),

--- a/videostore/direct_upload_test.go
+++ b/videostore/direct_upload_test.go
@@ -1,0 +1,95 @@
+package videostore
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	syncpb "go.viam.com/api/app/datasync/v1"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/utils"
+	"go.viam.com/test"
+	"go.viam.com/utils/rpc"
+)
+
+type fakeDataSyncServer struct {
+	syncpb.UnimplementedDataSyncServiceServer
+
+	gotMeta     *syncpb.UploadMetadata
+	gotAnyBytes bool
+}
+
+func (s *fakeDataSyncServer) FileUpload(stream syncpb.DataSyncService_FileUploadServer) error {
+	for {
+		req, err := stream.Recv()
+		if err != nil {
+			// EOF ends the stream; respond.
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
+		switch pkt := req.UploadPacket.(type) {
+		case *syncpb.FileUploadRequest_Metadata:
+			s.gotMeta = pkt.Metadata
+		case *syncpb.FileUploadRequest_FileContents:
+			if len(pkt.FileContents.GetData()) > 0 {
+				s.gotAnyBytes = true
+			}
+		}
+	}
+	return stream.SendAndClose(&syncpb.FileUploadResponse{FileId: "file-123"})
+}
+
+func TestDirectUploaderFileUploadSendsMetadataAndChunks(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+
+	// Env vars required by newDirectUploader.
+	t.Setenv(utils.APIKeyEnvVar, "fake-api-key")
+	t.Setenv(utils.APIKeyIDEnvVar, "fake-api-key-id")
+	t.Setenv(utils.MachinePartIDEnvVar, "part-123")
+
+	listener, err := net.Listen("tcp", "localhost:0")
+	test.That(t, err, test.ShouldBeNil)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	rpcServer, err := rpc.NewServer(logger, rpc.WithUnauthenticated())
+	test.That(t, err, test.ShouldBeNil)
+	t.Cleanup(func() { rpcServer.Stop() })
+
+	fake := &fakeDataSyncServer{}
+	err = rpcServer.RegisterServiceServer(context.Background(), &syncpb.DataSyncService_ServiceDesc, fake)
+	test.That(t, err, test.ShouldBeNil)
+
+	go rpcServer.Serve(listener)
+
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "clip.mp4")
+	err = os.WriteFile(path, []byte("hello world"), 0o600)
+	test.That(t, err, test.ShouldBeNil)
+
+	cfg := &DirectUploadConfig{
+		Enabled: true,
+		BaseURL: "http://" + listener.Addr().String(),
+	}
+	uploader, err := newDirectUploader(cfg, logger)
+	test.That(t, err, test.ShouldBeNil)
+	defer uploader.Close()
+
+	fileID, err := uploader.uploadFile(context.Background(), path, []string{"t1", "t2"}, []string{"d1"})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, fileID, test.ShouldEqual, "file-123")
+
+	test.That(t, fake.gotMeta, test.ShouldNotBeNil)
+	test.That(t, fake.gotMeta.GetPartId(), test.ShouldEqual, "part-123")
+	test.That(t, fake.gotMeta.GetType(), test.ShouldEqual, syncpb.DataType_DATA_TYPE_FILE)
+	test.That(t, fake.gotMeta.GetFileExtension(), test.ShouldEqual, ".mp4")
+	test.That(t, fake.gotMeta.GetTags(), test.ShouldResemble, []string{"t1", "t2"})
+	test.That(t, fake.gotMeta.GetDatasetIds(), test.ShouldResemble, []string{"d1"})
+	test.That(t, fake.gotAnyBytes, test.ShouldBeTrue)
+	test.That(t, filepath.IsAbs(fake.gotMeta.GetFileName()), test.ShouldBeTrue)
+}


### PR DESCRIPTION
Introduce an opt-in “direct upload” mode for video-store Save outputs.
When enabled, `save` writes the concatenated clip into a dedicated staging
directory under `storage_path` (avoiding datamanager watched
`upload_path`), and asynchronously uploads the file to Viam App via the
DataSync FileUpload API, with bounded retries and optional
delete-on-success.

Also extend the `save` DoCommand to accept per-request `tags` and
`dataset_ids` (applied only in direct upload mode), and automatically
derive a `videostore-metadata-...` tag from the `metadata` field. Update
module documentation to describe the new configuration and command
fields and their behavior.
