### PR TITLE
RSDK-13042    —      video-store using GetImages continues even if input is invalid repeatedly

### DIFF
--- a/videostore/fetch_frames_test.go
+++ b/videostore/fetch_frames_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"image"
 	"image/jpeg"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -20,9 +21,14 @@ import (
 // mockCamera implements camera.Camera for testing fetchFrames behavior.
 type mockCamera struct {
 	camera.Camera
-	name           resource.Name
+	// mu guards fields that may be modified mid-test while fetchFrames reads them
+	// like imagesToReturn. Otherwise this test is unsafe and go test's -race flag
+	// would get really upset.
+	mu             sync.Mutex
 	imagesToReturn []camera.NamedImage
-	returnError    error
+
+	name        resource.Name
+	returnError error
 }
 
 func (m *mockCamera) Name() resource.Name {
@@ -38,6 +44,8 @@ func (m *mockCamera) Images(
 	resource.ResponseMetadata,
 	error,
 ) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.returnError != nil {
 		return nil, resource.ResponseMetadata{}, m.returnError
 	}
@@ -197,6 +205,72 @@ func TestFetchFrames(t *testing.T) {
 		frameBytes, ok := frame.([]byte)
 		test.That(t, ok, test.ShouldBeTrue)
 		test.That(t, len(frameBytes), test.ShouldEqual, 0)
+	})
+
+	t.Run("Clears stale frame when camera switches to invalid MIME type", func(t *testing.T) {
+		jpegImage, err := camera.NamedImageFromBytes(jpegData, "color", rutils.MimeTypeJPEG)
+		test.That(t, err, test.ShouldBeNil)
+
+		mockCam := &mockCamera{
+			name: resource.NewName(camera.API, "test-camera"),
+			imagesToReturn: []camera.NamedImage{
+				jpegImage,
+			},
+		}
+
+		vs := &videostore{
+			config:      Config{},
+			logger:      logger,
+			latestFrame: &atomic.Value{},
+		}
+		vs.latestFrame.Store([]byte{})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		go vs.fetchFrames(ctx, FramePollerConfig{
+			Framerate: 30,
+			Camera:    mockCam,
+		})
+
+		// Poll until a valid frame is stored
+		timeout := time.After(5 * time.Second)
+		for {
+			frame := vs.latestFrame.Load()
+			frameBytes, ok := frame.([]byte)
+			if ok && len(frameBytes) > 0 {
+				break
+			}
+			select {
+			case <-timeout:
+				t.Fatal("timed out waiting for valid frame to be stored")
+			default:
+				time.Sleep(50 * time.Millisecond)
+			}
+		}
+
+		// Switch camera to return depth image
+		depthImage, err := camera.NamedImageFromBytes([]byte("fake depth data"), "depth", "image/vnd.viam.dep")
+		test.That(t, err, test.ShouldBeNil)
+		mockCam.mu.Lock()
+		mockCam.imagesToReturn = []camera.NamedImage{depthImage}
+		mockCam.mu.Unlock()
+
+		// Poll until the stale frame is cleared
+		timeout = time.After(5 * time.Second)
+		for {
+			frame := vs.latestFrame.Load()
+			frameBytes, ok := frame.([]byte)
+			if ok && frameBytes == nil {
+				break
+			}
+			select {
+			case <-timeout:
+				t.Fatal("timed out waiting for stale frame to be cleared")
+			default:
+				time.Sleep(50 * time.Millisecond)
+			}
+		}
 	})
 
 	t.Run("Continues on Images error", func(t *testing.T) {

--- a/videostore/fetch_frames_test.go
+++ b/videostore/fetch_frames_test.go
@@ -234,11 +234,13 @@ func TestFetchFrames(t *testing.T) {
 		})
 
 		// Poll until a valid frame is stored
+		var storedFrameBytes []byte
 		timeout := time.After(5 * time.Second)
 		for {
 			frame := vs.latestFrame.Load()
 			frameBytes, ok := frame.([]byte)
 			if ok && len(frameBytes) > 0 {
+				storedFrameBytes = frameBytes
 				break
 			}
 			select {
@@ -248,6 +250,8 @@ func TestFetchFrames(t *testing.T) {
 				time.Sleep(50 * time.Millisecond)
 			}
 		}
+		test.That(t, storedFrameBytes, test.ShouldNotBeNil)
+		test.That(t, len(storedFrameBytes), test.ShouldBeGreaterThan, 0)
 
 		// Switch camera to return depth image
 		depthImage, err := camera.NamedImageFromBytes([]byte("fake depth data"), "depth", "image/vnd.viam.dep")
@@ -257,11 +261,13 @@ func TestFetchFrames(t *testing.T) {
 		mockCam.mu.Unlock()
 
 		// Poll until the stale frame is cleared
+		var clearedFrameBytes []byte
 		timeout = time.After(5 * time.Second)
 		for {
 			frame := vs.latestFrame.Load()
 			frameBytes, ok := frame.([]byte)
 			if ok && frameBytes == nil {
+				clearedFrameBytes = frameBytes
 				break
 			}
 			select {
@@ -271,6 +277,222 @@ func TestFetchFrames(t *testing.T) {
 				time.Sleep(50 * time.Millisecond)
 			}
 		}
+		test.That(t, clearedFrameBytes, test.ShouldBeNil)
+	})
+
+	t.Run("Clears stale frame when 0 images returned", func(t *testing.T) {
+		jpegImage, err := camera.NamedImageFromBytes(jpegData, "color", rutils.MimeTypeJPEG)
+		test.That(t, err, test.ShouldBeNil)
+
+		mockCam := &mockCamera{
+			name: resource.NewName(camera.API, "test-camera"),
+			imagesToReturn: []camera.NamedImage{
+				jpegImage,
+			},
+		}
+
+		vs := &videostore{
+			config:      Config{},
+			logger:      logger,
+			latestFrame: &atomic.Value{},
+		}
+		vs.latestFrame.Store([]byte{})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		go vs.fetchFrames(ctx, FramePollerConfig{
+			Framerate: 30,
+			Camera:    mockCam,
+		})
+
+		// Poll until a valid frame is stored
+		var storedFrameBytes []byte
+		timeout := time.After(5 * time.Second)
+		for {
+			frame := vs.latestFrame.Load()
+			frameBytes, ok := frame.([]byte)
+			if ok && len(frameBytes) > 0 {
+				storedFrameBytes = frameBytes
+				break
+			}
+			select {
+			case <-timeout:
+				t.Fatal("timed out waiting for valid frame to be stored")
+			default:
+				time.Sleep(50 * time.Millisecond)
+			}
+		}
+		test.That(t, storedFrameBytes, test.ShouldNotBeNil)
+		test.That(t, len(storedFrameBytes), test.ShouldBeGreaterThan, 0)
+
+		// Switch camera to return 0 images
+		mockCam.mu.Lock()
+		mockCam.imagesToReturn = []camera.NamedImage{}
+		mockCam.mu.Unlock()
+
+		// Poll until the stale frame is cleared
+		var clearedFrameBytes []byte
+		timeout = time.After(5 * time.Second)
+		for {
+			frame := vs.latestFrame.Load()
+			frameBytes, ok := frame.([]byte)
+			if ok && frameBytes == nil {
+				clearedFrameBytes = frameBytes
+				break
+			}
+			select {
+			case <-timeout:
+				t.Fatal("timed out waiting for stale frame to be cleared")
+			default:
+				time.Sleep(50 * time.Millisecond)
+			}
+		}
+		test.That(t, clearedFrameBytes, test.ShouldBeNil)
+	})
+
+	t.Run("Clears stale frame when more than 1 image returned", func(t *testing.T) {
+		jpegImage, err := camera.NamedImageFromBytes(jpegData, "color", rutils.MimeTypeJPEG)
+		test.That(t, err, test.ShouldBeNil)
+
+		mockCam := &mockCamera{
+			name: resource.NewName(camera.API, "test-camera"),
+			imagesToReturn: []camera.NamedImage{
+				jpegImage,
+			},
+		}
+
+		vs := &videostore{
+			config:      Config{},
+			logger:      logger,
+			latestFrame: &atomic.Value{},
+		}
+		vs.latestFrame.Store([]byte{})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		go vs.fetchFrames(ctx, FramePollerConfig{
+			Framerate: 30,
+			Camera:    mockCam,
+		})
+
+		// Poll until a valid frame is stored
+		var storedFrameBytes []byte
+		timeout := time.After(5 * time.Second)
+		for {
+			frame := vs.latestFrame.Load()
+			frameBytes, ok := frame.([]byte)
+			if ok && len(frameBytes) > 0 {
+				storedFrameBytes = frameBytes
+				break
+			}
+			select {
+			case <-timeout:
+				t.Fatal("timed out waiting for valid frame to be stored")
+			default:
+				time.Sleep(50 * time.Millisecond)
+			}
+		}
+		test.That(t, storedFrameBytes, test.ShouldNotBeNil)
+		test.That(t, len(storedFrameBytes), test.ShouldBeGreaterThan, 0)
+
+		// Switch camera to return 2 images
+		secondImage, err := camera.NamedImageFromBytes(jpegData, "depth", rutils.MimeTypeJPEG)
+		test.That(t, err, test.ShouldBeNil)
+		mockCam.mu.Lock()
+		mockCam.imagesToReturn = []camera.NamedImage{jpegImage, secondImage}
+		mockCam.mu.Unlock()
+
+		// Poll until the stale frame is cleared
+		var clearedFrameBytes []byte
+		timeout = time.After(5 * time.Second)
+		for {
+			frame := vs.latestFrame.Load()
+			frameBytes, ok := frame.([]byte)
+			if ok && frameBytes == nil {
+				clearedFrameBytes = frameBytes
+				break
+			}
+			select {
+			case <-timeout:
+				t.Fatal("timed out waiting for stale frame to be cleared")
+			default:
+				time.Sleep(50 * time.Millisecond)
+			}
+		}
+		test.That(t, clearedFrameBytes, test.ShouldBeNil)
+	})
+
+	t.Run("Clears stale frame when Images() returns error", func(t *testing.T) {
+		jpegImage, err := camera.NamedImageFromBytes(jpegData, "color", rutils.MimeTypeJPEG)
+		test.That(t, err, test.ShouldBeNil)
+
+		mockCam := &mockCamera{
+			name: resource.NewName(camera.API, "test-camera"),
+			imagesToReturn: []camera.NamedImage{
+				jpegImage,
+			},
+		}
+
+		vs := &videostore{
+			config:      Config{},
+			logger:      logger,
+			latestFrame: &atomic.Value{},
+		}
+		vs.latestFrame.Store([]byte{})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		go vs.fetchFrames(ctx, FramePollerConfig{
+			Framerate: 30,
+			Camera:    mockCam,
+		})
+
+		// Poll until a valid frame is stored
+		var storedFrameBytes []byte
+		timeout := time.After(5 * time.Second)
+		for {
+			frame := vs.latestFrame.Load()
+			frameBytes, ok := frame.([]byte)
+			if ok && len(frameBytes) > 0 {
+				storedFrameBytes = frameBytes
+				break
+			}
+			select {
+			case <-timeout:
+				t.Fatal("timed out waiting for valid frame to be stored")
+			default:
+				time.Sleep(50 * time.Millisecond)
+			}
+		}
+		test.That(t, storedFrameBytes, test.ShouldNotBeNil)
+		test.That(t, len(storedFrameBytes), test.ShouldBeGreaterThan, 0)
+
+		// Switch camera to return an error
+		mockCam.mu.Lock()
+		mockCam.returnError = errors.New("camera unavailable")
+		mockCam.mu.Unlock()
+
+		// Poll until the stale frame is cleared
+		var clearedFrameBytes []byte
+		timeout = time.After(5 * time.Second)
+		for {
+			frame := vs.latestFrame.Load()
+			frameBytes, ok := frame.([]byte)
+			if ok && frameBytes == nil {
+				clearedFrameBytes = frameBytes
+				break
+			}
+			select {
+			case <-timeout:
+				t.Fatal("timed out waiting for stale frame to be cleared")
+			default:
+				time.Sleep(50 * time.Millisecond)
+			}
+		}
+		test.That(t, clearedFrameBytes, test.ShouldBeNil)
 	})
 
 	t.Run("Continues on Images error", func(t *testing.T) {

--- a/videostore/fetch_frames_test.go
+++ b/videostore/fetch_frames_test.go
@@ -495,6 +495,56 @@ func TestFetchFrames(t *testing.T) {
 		test.That(t, clearedFrameBytes, test.ShouldBeNil)
 	})
 
+	t.Run("Clears stale frame when Bytes() errors", func(t *testing.T) {
+		// Build a NamedImage that will error on Bytes(): use an unsupported mime type
+		// so that rimage.EncodeImage hits its default error case.
+		badImg := image.NewNRGBA(image.Rect(0, 0, 1, 1))
+		badNamedImage, err := camera.NamedImageFromImage(badImg, "color", "image/bogus")
+		test.That(t, err, test.ShouldBeNil)
+
+		mockCam := &mockCamera{
+			name:           resource.NewName(camera.API, "test-camera"),
+			imagesToReturn: []camera.NamedImage{badNamedImage},
+		}
+
+		vs := &videostore{
+			config:      Config{},
+			logger:      logger,
+			latestFrame: &atomic.Value{},
+		}
+		// Pre-seed a stale frame to verify it gets cleared.
+		vs.latestFrame.Store([]byte("stale"))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		go vs.fetchFrames(ctx, FramePollerConfig{
+			Framerate: 30,
+			Camera:    mockCam,
+		})
+
+		// Poll until the stale frame is cleared.
+		timeout := time.After(5 * time.Second)
+		for {
+			frame := vs.latestFrame.Load()
+			frameBytes, ok := frame.([]byte)
+			if ok && frameBytes == nil {
+				break
+			}
+			select {
+			case <-timeout:
+				t.Fatal("timed out waiting for stale frame to be cleared after Bytes() error")
+			default:
+				time.Sleep(50 * time.Millisecond)
+			}
+		}
+
+		frame := vs.latestFrame.Load()
+		frameBytes, ok := frame.([]byte)
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, frameBytes, test.ShouldBeNil)
+	})
+
 	t.Run("Continues on Images error", func(t *testing.T) {
 		mockCam := &mockCamera{
 			name:        resource.NewName(camera.API, "test-camera"),

--- a/videostore/fetch_frames_test.go
+++ b/videostore/fetch_frames_test.go
@@ -254,7 +254,7 @@ func TestFetchFrames(t *testing.T) {
 		test.That(t, len(storedFrameBytes), test.ShouldBeGreaterThan, 0)
 
 		// Switch camera to return depth image
-		depthImage, err := camera.NamedImageFromBytes([]byte("fake depth data"), "depth", "image/vnd.viam.dep")
+		depthImage, err := camera.NamedImageFromBytes([]byte("fake depth data"), "depth", rutils.MimeTypeRawDepth)
 		test.That(t, err, test.ShouldBeNil)
 		mockCam.mu.Lock()
 		mockCam.imagesToReturn = []camera.NamedImage{depthImage}

--- a/videostore/videostore.go
+++ b/videostore/videostore.go
@@ -527,7 +527,9 @@ func (vs *videostore) Save(_ context.Context, r *SaveRequest) (*SaveResponse, er
 // clearLatestFrame sets the latest frame atomic to a nil byte slice.
 // Useful to remove stale frames when underlying cam is unhealthy.
 func (vs *videostore) clearLatestFrame() {
-	vs.latestFrame.Store([]byte(nil))
+	if frame := vs.latestFrame.Load(); frame != nil {
+		vs.latestFrame.Store([]byte(nil))
+	}
 }
 
 func (vs *videostore) fetchFrames(ctx context.Context, framePoller FramePollerConfig,

--- a/videostore/videostore.go
+++ b/videostore/videostore.go
@@ -524,6 +524,12 @@ func (vs *videostore) Save(_ context.Context, r *SaveRequest) (*SaveResponse, er
 	return &SaveResponse{Filename: uploadFileName}, nil
 }
 
+// clearLatestFrame sets the latest frame atomic to a nil byte slice.
+// Useful to remove stale frames when underlying cam is unhealthy.
+func (vs *videostore) clearLatestFrame() {
+	vs.latestFrame.Store([]byte(nil))
+}
+
 func (vs *videostore) fetchFrames(ctx context.Context, framePoller FramePollerConfig,
 ) {
 	frameInterval := time.Second / time.Duration(framePoller.Framerate)
@@ -541,6 +547,7 @@ func (vs *videostore) fetchFrames(ctx context.Context, framePoller FramePollerCo
 					framePoller.Camera.Name(),
 					err,
 				)
+				vs.clearLatestFrame()
 				time.Sleep(retryIntervalSeconds * time.Second)
 				continue
 			}
@@ -550,6 +557,7 @@ func (vs *videostore) fetchFrames(ctx context.Context, framePoller FramePollerCo
 					"no images received from camera %s",
 					framePoller.Camera.Name(),
 				)
+				vs.clearLatestFrame()
 				time.Sleep(retryIntervalSeconds * time.Second)
 				continue
 			} else if len(namedImages) > 1 {
@@ -558,6 +566,7 @@ func (vs *videostore) fetchFrames(ctx context.Context, framePoller FramePollerCo
 					len(namedImages),
 					framePoller.Camera.Name(),
 				)
+				vs.clearLatestFrame()
 				time.Sleep(retryIntervalSeconds * time.Second)
 				continue
 			}
@@ -566,11 +575,13 @@ func (vs *videostore) fetchFrames(ctx context.Context, framePoller FramePollerCo
 			data, err := namedImage.Bytes(ctx)
 			if err != nil {
 				vs.logger.Warnf("failed to get bytes from image: %v", err)
+				vs.clearLatestFrame()
 				time.Sleep(retryIntervalSeconds * time.Second)
 				continue
 			}
 			if actualMimeType, _ := rutils.CheckLazyMIMEType(namedImage.MimeType()); actualMimeType != rutils.MimeTypeJPEG {
 				vs.logger.Warnf("expected image mime type %s got %s: ", rutils.MimeTypeJPEG, actualMimeType)
+				vs.clearLatestFrame()
 				continue
 			}
 			vs.latestFrame.Store(data)


### PR DESCRIPTION
[RSDK-13042](https://viam.atlassian.net/browse/RSDK-13042)

## Bug Summary
**Steps to reproduce :**

Use depth camera e.g. Realsense and hook it up as the underlying camera to a video-store.

Configure the camera to return only a color image at first and store some video, then change it to return only a depth map in its GetImages response e.g. RealSense. 

**Expected behavior :**

Returns depth mime type invalid error, and stops storing video.

**Actual behavior :**

Returns depth mime type invalid error, but continues storing stale color frame as video.

## Manual Tests

Config: 
```
{
  "components": [
    {
      "name": "vs",
      "api": "rdk:component:camera",
      "model": "viam:video:storage",
      "attributes": {
        "camera": "oak-d",
        "sync": "data_manager-1",
        "storage": {
          "size_gb": 1
        }
      },
      "depends_on": [
        "data_manager-1"
      ]
    },
    {
      "name": "oak-d",
      "api": "rdk:component:camera",
      "model": "viam:luxonis:oak-d",
      "attributes": {
        "sensors": [
          "color"
        ]
      }
    }
  ],
  "services": [
    {
      "name": "data_manager-1",
      "api": "rdk:service:data_manager",
      "model": "rdk:builtin:builtin",
      "attributes": {
        "additional_sync_paths": [],
        "sync_interval_mins": 0.1,
        "capture_dir": "",
        "tags": []
      }
    }
  ],
  "modules": [
    {
      "type": "registry",
      "name": "viam_oak",
      "module_id": "viam:oak",
      "version": "latest"
    },
    {
      "type": "local",
      "name": "local-vs",
      "executable_path": "/Users/seanyu/Projects/sean-video-store/bin/darwin-arm64/video-store"
    }
  ]
}
```

Verified video saves well. Change sensors from `["color"]` to `["depth]`. Observed:

`3/12/2026, 1:45:28 PM warn local-vs.rdk:component:camera/vs     videostore/videostore.go:583 expected image mime type image/jpeg got image/vnd.viam.dep:   log_ts 2026-03-12T17:45:28.138Z`

and no more video saved.

After changing back to `["color"]` there is one corrupted video, but the video resource recovers and keeps writing segments.

## PR
1 reviewer

This was not vibe coded sorry for the slop earlier

[RSDK-13042]: https://viam.atlassian.net/browse/RSDK-13042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

TODO: make an RC, bump viamrtsp, and consume this change there