### PR TITLE
Reduce FFmpeg log level in debug mode to stop error log flooding

### DIFF
--- a/cmd/module/cmd.go
+++ b/cmd/module/cmd.go
@@ -17,8 +17,10 @@ func main() {
 }
 
 func mainWithArgs(ctx context.Context, _ []string, logger logging.Logger) error {
+	// Use "warning" even in debug mode because FFmpeg's debug/info output goes to stderr,
+	// which the module manager captures as error-level logs, flooding the log stream.
 	if logger.GetLevel() == logging.DEBUG {
-		vsutils.SetLibAVLogLevel("debug")
+		vsutils.SetLibAVLogLevel("warning")
 	} else {
 		vsutils.SetLibAVLogLevel("fatal")
 	}


### PR DESCRIPTION
## Summary

When the video-store module runs with debug logging enabled, FFmpeg's per-frame codec diagnostics (MJPEG decoder marker parsing, libx264 QP/slice stats, segment muxer PTS/DTS) flood the error log stream at hundreds of lines per second. This PR lowers FFmpeg's verbosity in debug mode so real issues remain visible without the noise.

## Changes

- **cmd/module/cmd.go**: Set FFmpeg's libav log level to `warning` (instead of `debug`) when the module logger is at `DEBUG`. Added a comment explaining why: FFmpeg writes debug/info output to stderr, which the Viam module manager captures as error-level logs.

## Why this matters

FFmpeg's custom log callback (`video_store_custom_av_log_callback` in `videostore/utils/utils.c`) uses `av_log_default_callback`, which writes to stderr. The Viam module manager labels all stderr output from modules as `error`-level and tags them `rdk.modmanager.viam_video-store.StdErr`. At `debug` level, FFmpeg emits extensive codec internals per frame, which is not useful for debugging the video-store module itself and overwhelms the log stream on any machine running the module in debug mode.

## Testing

- Change is a single-line constant update; no new tests needed.
- To validate on a live machine: set the module log level to `debug` and confirm that `rdk.modmanager.viam_video-store.StdErr` no longer emits per-frame FFmpeg decoder/encoder/segment lines. Real FFmpeg warnings (e.g. `moov atom not found`) should still surface.

## Claude Code Prompts Used

- "I am seeing a lot of error logs on my Viam machine... Can you check the video store module code and figure out why we are having so many error logs?"
- "Can you check the error logs for that machine again?"
- "woud we still have this issue if we use the info level?"
- "let's do info" → "Actually you were right, let's use warning. Please also add a comment explaining why"
- "yes, let's open a PR"