### PR TITLE
Use hosted runner instead of buildjet

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           - platform: linux/amd64
             runs-on: ubuntu-latest
           - platform: linux/arm64
-            runs-on: buildjet-8vcpu-ubuntu-2204-arm
+            runs-on: github-linux-arm64-8core
           - platform: darwin/arm64
             runs-on: macos-latest
 


### PR DESCRIPTION
## Description

Buildjet no longer picks up consistently; moving to our hosted runner for arm64.

[Recent worker hang](https://github.com/viam-modules/video-store/actions/runs/25135283067/job/73671958598?pr=89)