### PR TITLE
Support cameras with multiple sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Additionally, make sure to add your configured data manager service to the `depe
 
 | Attribute       | Sub-Attribute     | Type    | Required | Description                                                                                       |
 |-----------------|-------------------|---------|-----------|---------------------------------------------------------------------------------------------------|
-| `camera`        |                   | string  | no  | Name of the source camera to read images from. If not provided, video-store will not save video. If the camera is not an rtp passthrough source and multiple image sources are received via GetImages, video store will return an error, as image source name disambiguation is not supported at the time. |
+| `camera`        |                   | string  | no  | Name of the source camera to read images from. If not provided, video-store will not save video. If the camera is not an rtp passthrough source and returns multiple image sources via GetImages, set `source_name` to select one. |
+| `source_name`   |                   | string  | no  | Name of the image source to select when the camera returns multiple. Required if the camera has multiple sources; leave unset for single-source cameras. |
 | `sync`          |                   | string  | yes  | Name of the dependency datamanager service.                                                       |
 | `storage`       |                   | object  | yes  |                                                                                                   |
 |                 | `size_gb`         | integer | yes  | Total amount of allocated storage in gigabytes. If you reduce the amound of allocated storage while the storage exceeds the allocated amount, the oldest clips get deleted until the storage size is below the configured max. |

--- a/model/camera/config.go
+++ b/model/camera/config.go
@@ -27,12 +27,13 @@ type Video struct {
 
 // Config is the configuration for the video storage camera component.
 type Config struct {
-	Camera    string  `json:"camera,omitempty"`
-	Sync      string  `json:"sync"`
-	Storage   Storage `json:"storage"`
-	Video     Video   `json:"video,omitempty"`
-	Framerate int     `json:"framerate,omitempty"`
-	YUYV      bool    `json:"yuyv,omitempty"`
+	Camera     string  `json:"camera,omitempty"`
+	SourceName string  `json:"source_name,omitempty"`
+	Sync       string  `json:"sync"`
+	Storage    Storage `json:"storage"`
+	Video      Video   `json:"video,omitempty"`
+	Framerate  int     `json:"framerate,omitempty"`
+	YUYV       bool    `json:"yuyv,omitempty"`
 }
 
 // Validate validates the configuration for the video storage camera component.
@@ -111,9 +112,10 @@ func ToFrameVideoStoreVideoConfig(
 		Encoder: applyVideoEncoderDefaults(config.Video),
 		Storage: storage,
 		FramePoller: videostore.FramePollerConfig{
-			Framerate: framerate,
-			YUYV:      config.YUYV,
-			Camera:    camera,
+			Framerate:  framerate,
+			YUYV:       config.YUYV,
+			Camera:     camera,
+			SourceName: config.SourceName,
 		},
 	}
 

--- a/videostore/config.go
+++ b/videostore/config.go
@@ -133,9 +133,11 @@ func (c EncoderConfig) Validate() error {
 
 // FramePollerConfig is the config for the frame poller.
 type FramePollerConfig struct {
-	Camera    camera.Camera
-	Framerate int
-	YUYV      bool
+	Camera camera.Camera
+	// SourceName picks a named image source; empty expects a single-source camera.
+	SourceName string
+	Framerate  int
+	YUYV       bool
 }
 
 // Validate returns an error if the	FramePollerConfig is invalid.

--- a/videostore/fetch_frames_test.go
+++ b/videostore/fetch_frames_test.go
@@ -26,6 +26,8 @@ type mockCamera struct {
 	// would get really upset.
 	mu             sync.Mutex
 	imagesToReturn []camera.NamedImage
+	// lastFilter captures the most recent filterSourceNames argument passed to Images.
+	lastFilter []string
 
 	name        resource.Name
 	returnError error
@@ -37,7 +39,7 @@ func (m *mockCamera) Name() resource.Name {
 
 func (m *mockCamera) Images(
 	_ context.Context,
-	_ []string,
+	filterSourceNames []string,
 	_ map[string]interface{},
 ) (
 	[]camera.NamedImage,
@@ -46,6 +48,7 @@ func (m *mockCamera) Images(
 ) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.lastFilter = filterSourceNames
 	if m.returnError != nil {
 		return nil, resource.ResponseMetadata{}, m.returnError
 	}
@@ -132,7 +135,7 @@ func TestFetchFrames(t *testing.T) {
 		test.That(t, len(frameBytes), test.ShouldEqual, 0)
 	})
 
-	t.Run("Fails with multiple images", func(t *testing.T) {
+	t.Run("Fails with multiple images when source_name unset", func(t *testing.T) {
 		colorImage, err := camera.NamedImageFromBytes(jpegData, "color", rutils.MimeTypeJPEG)
 		test.That(t, err, test.ShouldBeNil)
 		depthImage, err := camera.NamedImageFromBytes(jpegData, "depth", rutils.MimeTypeJPEG)
@@ -574,5 +577,168 @@ func TestFetchFrames(t *testing.T) {
 		frameBytes, ok := frame.([]byte)
 		test.That(t, ok, test.ShouldBeTrue)
 		test.That(t, len(frameBytes), test.ShouldEqual, 0)
+	})
+
+	t.Run("Passes nil filter to Images when source_name unset", func(t *testing.T) {
+		namedImage, err := camera.NamedImageFromBytes(jpegData, "default", rutils.MimeTypeJPEG)
+		test.That(t, err, test.ShouldBeNil)
+
+		mockCam := &mockCamera{
+			name:           resource.NewName(camera.API, "test-camera"),
+			imagesToReturn: []camera.NamedImage{namedImage},
+		}
+
+		vs := &videostore{
+			config:      Config{},
+			logger:      logger,
+			latestFrame: &atomic.Value{},
+		}
+		vs.latestFrame.Store([]byte{})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		go vs.fetchFrames(ctx, FramePollerConfig{
+			Framerate: 10,
+			Camera:    mockCam,
+		})
+
+		time.Sleep(200 * time.Millisecond)
+
+		mockCam.mu.Lock()
+		filter := mockCam.lastFilter
+		mockCam.mu.Unlock()
+		test.That(t, filter, test.ShouldBeNil)
+	})
+
+	t.Run("Selects matching named image when source_name set", func(t *testing.T) {
+		// Build two JPEGs of different sizes so their bytes differ and we can
+		// verify which one was selected.
+		colorBuf := new(bytes.Buffer)
+		test.That(t, jpeg.Encode(colorBuf, image.NewRGBA(image.Rect(0, 0, 320, 240)), nil), test.ShouldBeNil)
+		depthBuf := new(bytes.Buffer)
+		test.That(t, jpeg.Encode(depthBuf, image.NewRGBA(image.Rect(0, 0, 640, 480)), nil), test.ShouldBeNil)
+		test.That(t, bytes.Equal(colorBuf.Bytes(), depthBuf.Bytes()), test.ShouldBeFalse)
+
+		colorImage, err := camera.NamedImageFromBytes(colorBuf.Bytes(), "color", rutils.MimeTypeJPEG)
+		test.That(t, err, test.ShouldBeNil)
+		depthImage, err := camera.NamedImageFromBytes(depthBuf.Bytes(), "depth", rutils.MimeTypeJPEG)
+		test.That(t, err, test.ShouldBeNil)
+
+		mockCam := &mockCamera{
+			name:           resource.NewName(camera.API, "test-camera"),
+			imagesToReturn: []camera.NamedImage{colorImage, depthImage},
+		}
+
+		vs := &videostore{
+			config:      Config{},
+			logger:      logger,
+			latestFrame: &atomic.Value{},
+		}
+		vs.latestFrame.Store([]byte{})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		go vs.fetchFrames(ctx, FramePollerConfig{
+			Framerate:  10,
+			Camera:     mockCam,
+			SourceName: "depth",
+		})
+
+		// Poll until a frame matching the depth image is stored.
+		timeout := time.After(2 * time.Second)
+		for {
+			frame := vs.latestFrame.Load()
+			if frameBytes, ok := frame.([]byte); ok && bytes.Equal(frameBytes, depthBuf.Bytes()) {
+				break
+			}
+			select {
+			case <-timeout:
+				t.Fatal("timed out waiting for depth frame to be stored")
+			default:
+				time.Sleep(50 * time.Millisecond)
+			}
+		}
+
+		mockCam.mu.Lock()
+		filter := mockCam.lastFilter
+		mockCam.mu.Unlock()
+		test.That(t, filter, test.ShouldResemble, []string{"depth"})
+	})
+
+	t.Run("Clears frame when source_name has no match", func(t *testing.T) {
+		// Camera ignores the filter and returns only sources the user did not ask for.
+		colorImage, err := camera.NamedImageFromBytes(jpegData, "color", rutils.MimeTypeJPEG)
+		test.That(t, err, test.ShouldBeNil)
+
+		mockCam := &mockCamera{
+			name:           resource.NewName(camera.API, "test-camera"),
+			imagesToReturn: []camera.NamedImage{colorImage},
+		}
+
+		vs := &videostore{
+			config:      Config{},
+			logger:      logger,
+			latestFrame: &atomic.Value{},
+		}
+		vs.latestFrame.Store([]byte("stale"))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		go vs.fetchFrames(ctx, FramePollerConfig{
+			Framerate:  30,
+			Camera:     mockCam,
+			SourceName: "depth",
+		})
+
+		// Poll until the stale frame is cleared.
+		timeout := time.After(5 * time.Second)
+		for {
+			frame := vs.latestFrame.Load()
+			if frameBytes, ok := frame.([]byte); ok && frameBytes == nil {
+				break
+			}
+			select {
+			case <-timeout:
+				t.Fatal("timed out waiting for stale frame to be cleared")
+			default:
+				time.Sleep(50 * time.Millisecond)
+			}
+		}
+	})
+}
+
+func TestPickImage(t *testing.T) {
+	mustImg := func(name string) camera.NamedImage {
+		ni, err := camera.NamedImageFromBytes([]byte("data-"+name), name, rutils.MimeTypeJPEG)
+		test.That(t, err, test.ShouldBeNil)
+		return ni
+	}
+
+	t.Run("empty source_name with single image returns it", func(t *testing.T) {
+		only := mustImg("only")
+		got, err := pickImage([]camera.NamedImage{only}, "")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, got.SourceName, test.ShouldEqual, "only")
+	})
+
+	t.Run("empty source_name with multiple images errors", func(t *testing.T) {
+		_, err := pickImage([]camera.NamedImage{mustImg("a"), mustImg("b")}, "")
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "set source_name")
+	})
+
+	t.Run("source_name selects matching image", func(t *testing.T) {
+		got, err := pickImage([]camera.NamedImage{mustImg("color"), mustImg("depth")}, "depth")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, got.SourceName, test.ShouldEqual, "depth")
+	})
+
+	t.Run("source_name with no match errors", func(t *testing.T) {
+		_, err := pickImage([]camera.NamedImage{mustImg("color")}, "depth")
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, `"depth"`)
 	})
 }

--- a/videostore/fetch_frames_test.go
+++ b/videostore/fetch_frames_test.go
@@ -26,8 +26,6 @@ type mockCamera struct {
 	// would get really upset.
 	mu             sync.Mutex
 	imagesToReturn []camera.NamedImage
-	// lastFilter captures the most recent filterSourceNames argument passed to Images.
-	lastFilter []string
 
 	name        resource.Name
 	returnError error
@@ -39,7 +37,7 @@ func (m *mockCamera) Name() resource.Name {
 
 func (m *mockCamera) Images(
 	_ context.Context,
-	filterSourceNames []string,
+	_ []string,
 	_ map[string]interface{},
 ) (
 	[]camera.NamedImage,
@@ -48,7 +46,6 @@ func (m *mockCamera) Images(
 ) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.lastFilter = filterSourceNames
 	if m.returnError != nil {
 		return nil, resource.ResponseMetadata{}, m.returnError
 	}
@@ -579,38 +576,6 @@ func TestFetchFrames(t *testing.T) {
 		test.That(t, len(frameBytes), test.ShouldEqual, 0)
 	})
 
-	t.Run("Passes nil filter to Images when source_name unset", func(t *testing.T) {
-		namedImage, err := camera.NamedImageFromBytes(jpegData, "default", rutils.MimeTypeJPEG)
-		test.That(t, err, test.ShouldBeNil)
-
-		mockCam := &mockCamera{
-			name:           resource.NewName(camera.API, "test-camera"),
-			imagesToReturn: []camera.NamedImage{namedImage},
-		}
-
-		vs := &videostore{
-			config:      Config{},
-			logger:      logger,
-			latestFrame: &atomic.Value{},
-		}
-		vs.latestFrame.Store([]byte{})
-
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-
-		go vs.fetchFrames(ctx, FramePollerConfig{
-			Framerate: 10,
-			Camera:    mockCam,
-		})
-
-		time.Sleep(200 * time.Millisecond)
-
-		mockCam.mu.Lock()
-		filter := mockCam.lastFilter
-		mockCam.mu.Unlock()
-		test.That(t, filter, test.ShouldBeNil)
-	})
-
 	t.Run("Selects matching named image when source_name set", func(t *testing.T) {
 		// Build two JPEGs of different sizes so their bytes differ and we can
 		// verify which one was selected.
@@ -660,11 +625,6 @@ func TestFetchFrames(t *testing.T) {
 				time.Sleep(50 * time.Millisecond)
 			}
 		}
-
-		mockCam.mu.Lock()
-		filter := mockCam.lastFilter
-		mockCam.mu.Unlock()
-		test.That(t, filter, test.ShouldResemble, []string{"depth"})
 	})
 
 	t.Run("Clears frame when source_name has no match", func(t *testing.T) {

--- a/videostore/videostore.go
+++ b/videostore/videostore.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/viam-modules/video-store/videostore/indexer"
 	vsutils "github.com/viam-modules/video-store/videostore/utils"
+	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/video"
@@ -538,6 +539,30 @@ func (vs *videostore) clearLatestFrame() {
 	}
 }
 
+// pickImage selects the image to feed into the encoder from a non-empty
+// Images() response. If sourceName is empty the response must contain exactly
+// one image; otherwise the image with a matching SourceName wins.
+//
+// filterSourceNames passed to camera.Images() is a hint to the upstream
+// camera; not every implementation honors it. Matching by SourceName here
+// keeps a camera that ignores the filter (and returns all its sources) from
+// silently feeding the wrong stream into the video store.
+func pickImage(images []camera.NamedImage, sourceName string) (camera.NamedImage, error) {
+	if sourceName == "" {
+		if len(images) > 1 {
+			return camera.NamedImage{}, fmt.Errorf(
+				"received %d images; set source_name in the config to select one", len(images))
+		}
+		return images[0], nil
+	}
+	for _, ni := range images {
+		if ni.SourceName == sourceName {
+			return ni, nil
+		}
+	}
+	return camera.NamedImage{}, fmt.Errorf("no image with source_name %q", sourceName)
+}
+
 func (vs *videostore) fetchFrames(ctx context.Context, framePoller FramePollerConfig,
 ) {
 	frameInterval := time.Second / time.Duration(framePoller.Framerate)
@@ -548,7 +573,11 @@ func (vs *videostore) fetchFrames(ctx context.Context, framePoller FramePollerCo
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			namedImages, _, err := framePoller.Camera.Images(ctx, nil, nil)
+			var filter []string
+			if framePoller.SourceName != "" {
+				filter = []string{framePoller.SourceName}
+			}
+			namedImages, _, err := framePoller.Camera.Images(ctx, filter, nil)
 			if err != nil {
 				vs.logger.Warnf(
 					"failed to get images from camera %s: %v",
@@ -568,18 +597,15 @@ func (vs *videostore) fetchFrames(ctx context.Context, framePoller FramePollerCo
 				vs.clearLatestFrame()
 				time.Sleep(retryIntervalSeconds * time.Second)
 				continue
-			} else if len(namedImages) > 1 {
-				vs.logger.Errorf(
-					"received %d images from camera %s. Multiple image sources is not supported.",
-					len(namedImages),
-					framePoller.Camera.Name(),
-				)
+			}
+
+			namedImage, err := pickImage(namedImages, framePoller.SourceName)
+			if err != nil {
+				vs.logger.Errorf("camera %s: %v", framePoller.Camera.Name(), err)
 				vs.clearLatestFrame()
 				time.Sleep(retryIntervalSeconds * time.Second)
 				continue
 			}
-
-			namedImage := namedImages[0]
 			data, err := namedImage.Bytes(ctx)
 			if err != nil {
 				vs.logger.Warnf("failed to get bytes from image: %v", err)


### PR DESCRIPTION
## Summary
- Add an optional `source_name` config field so a video-store camera can be paired with a multi-source upstream (e.g. RealSense `color`/`depth`).
- When set, it's passed as `filterSourceNames` to `camera.Images()` and used to pick the matching `NamedImage` from the response — defending against upstreams that ignore the filter.
- When unset, behavior is unchanged: the upstream is expected to return exactly one image.

## Test plan
- [x] Manually configure a video-store on top of a RealSense with `source_name: "color"` and confirm clips contain the color stream
- [x] Confirm that single-source cameras still work without additional configuration