### PR TITLE
Add cgo accessible logging shim for the custom ffmpeg log callback

### DIFF
--- a/cmd/module/cmd.go
+++ b/cmd/module/cmd.go
@@ -22,7 +22,7 @@ func mainWithArgs(ctx context.Context, _ []string, logger logging.Logger) error 
 	} else {
 		vsutils.SetLibAVLogLevel("fatal")
 	}
-	vsutils.SetFFmpegLogCallback()
+	vsutils.SetFFmpegLogCallback(logger)
 
 	module, err := module.NewModuleFromArgs(ctx)
 	if err != nil {

--- a/cmd/module/cmd.go
+++ b/cmd/module/cmd.go
@@ -27,7 +27,7 @@ func mainWithArgs(ctx context.Context, _ []string, logger logging.Logger) error 
 	vsutils.SetFFmpegLogCallback(logger)
 
 	// NewModule, not NewModuleFromArgs: latter spawns its own moduleLogger, stranding our ffmpeg sublogger on stdout fallback.
-	if len(os.Args) < 2 {
+	if len(os.Args) < 2 { //nolint:mnd
 		return errors.New("need socket path as command line argument")
 	}
 	module, err := module.NewModule(ctx, os.Args[1], logger)

--- a/cmd/module/cmd.go
+++ b/cmd/module/cmd.go
@@ -3,6 +3,8 @@ package main
 
 import (
 	"context"
+	"errors"
+	"os"
 
 	cam "github.com/viam-modules/video-store/model/camera"
 	vsutils "github.com/viam-modules/video-store/videostore/utils"
@@ -24,7 +26,11 @@ func mainWithArgs(ctx context.Context, _ []string, logger logging.Logger) error 
 	}
 	vsutils.SetFFmpegLogCallback(logger)
 
-	module, err := module.NewModuleFromArgs(ctx)
+	// NewModule, not NewModuleFromArgs: latter spawns its own moduleLogger, stranding our ffmpeg sublogger on stdout fallback.
+	if len(os.Args) < 2 {
+		return errors.New("need socket path as command line argument")
+	}
+	module, err := module.NewModule(ctx, os.Args[1], logger)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	go.viam.com/test v1.2.4
 	go.viam.com/utils v0.3.1
 	golang.org/x/mobile v0.0.0-20240112133503-c713f31d574b
-	golang.org/x/sys v0.37.0
 	golang.org/x/tools v0.36.0
 	gotest.tools/gotestsum v1.12.2
 )
@@ -215,6 +214,7 @@ require (
 	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.17.0 // indirect
+	golang.org/x/sys v0.37.0 // indirect
 	golang.org/x/term v0.34.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 	golang.org/x/time v0.12.0 // indirect

--- a/videostore/utils/utils.c
+++ b/videostore/utils/utils.c
@@ -4,6 +4,11 @@
 #include <stdio.h>
 #include <string.h>
 
+// Implemented in Go (//export videoStoreGoFFmpegLog). Routes the formatted line
+// into the module's logging.Logger so FFmpeg output flows through the same sink
+// as the rest of the module.
+extern void videoStoreGoFFmpegLog(int level, const char *msg);
+
 // Matches FFmpeg's internal LINE_SZ in libavutil/log.c (not exposed in public headers).
 #define VIDEO_STORE_LOG_LINE_SZ 1024
 
@@ -92,29 +97,7 @@ void video_store_custom_av_log_callback(void *ptr, int level, const char *fmt, v
     int print_prefix = 1;
     char line[VIDEO_STORE_LOG_LINE_SZ];
     av_log_format_line(ptr, level, fmt, vargs, line, VIDEO_STORE_LOG_LINE_SZ, &print_prefix);
-    const char *level_str;
-    if (level <= AV_LOG_FATAL) {
-        level_str = "Fatal";
-    } else if (level <= AV_LOG_ERROR) {
-        level_str = "Error";
-    } else if (level <= AV_LOG_WARNING) {
-        level_str = "Warn";
-    } else if (level <= AV_LOG_INFO) {
-        level_str = "Info";
-    } else if (level <= AV_LOG_VERBOSE) {
-        level_str = "Verbose";
-    } else {
-        level_str = "Debug";
-    }
-    // RDK captures stderr as error-level logs, so only write warnings and above there.
-    // Info/verbose/debug go to stdout to avoid misleading error noise in production.
-    if (level <= AV_LOG_WARNING) {
-        fprintf(stderr, "[FFmpeg %s] %s", level_str, line);
-        fflush(stderr);
-    } else {
-        fprintf(stdout, "[FFmpeg %s] %s", level_str, line);
-        fflush(stdout);
-    }
+    videoStoreGoFFmpegLog(level, line);
 }
 
 void video_store_set_custom_av_log_callback() {

--- a/videostore/utils/utils.go
+++ b/videostore/utils/utils.go
@@ -126,8 +126,10 @@ func ffmpegLogLevel(loglevel C.int) {
 // SetFFmpegLogCallback sets the custom log callback for ffmpeg.
 // WARNING: this is global for the entire OS process. Any other library or component
 // using FFmpeg in the same process will inherit this callback.
-// Routes warnings and above to stderr, info/verbose/debug to stdout.
-func SetFFmpegLogCallback() {
+// All FFmpeg log lines are routed through logger under an "ffmpeg" sublogger.
+func SetFFmpegLogCallback(logger logging.Logger) {
+	sub := logger.Sublogger("ffmpeg")
+	ffmpegLogger.Store(&sub)
 	C.video_store_set_custom_av_log_callback()
 }
 

--- a/videostore/utils/utils_ffmpeg_log_cgo.go
+++ b/videostore/utils/utils_ffmpeg_log_cgo.go
@@ -82,8 +82,8 @@ func videoStoreGoFFmpegLog(level C.int, msg *C.char) {
 	line := strings.TrimRight(C.GoString(msg), "\n")
 	switch {
 	case level <= C.AV_LOG_ERROR:
-		// AV_LOG_PANIC and AV_LOG_FATAL fall in here on purpose: zap's Fatal
-		// would os.Exit and we don't want a recoverable libav fatal to take
+		// AV_LOG_PANIC and AV_LOG_FATAL fall in here on purpose: logger.Fatal
+		// calls os.Exit and we don't want a recoverable libav fatal to take
 		// down the module.
 		logger.Error(line)
 	case level <= C.AV_LOG_WARNING:

--- a/videostore/utils/utils_ffmpeg_log_cgo.go
+++ b/videostore/utils/utils_ffmpeg_log_cgo.go
@@ -19,7 +19,14 @@ static void test_set_av_log_level(int level) {
 }
 */
 import "C"
-import "unsafe"
+
+import (
+	"strings"
+	"sync/atomic"
+	"unsafe"
+
+	"go.viam.com/rdk/logging"
+)
 
 // avLog* constants mirror libavutil/log.h integer values.
 // These exist alongside SetLibAVLogLevel (which takes a string) so that
@@ -56,4 +63,33 @@ func getAVLogLevel() int {
 // Intended for use in tests to save and restore the log level around subtests.
 func setAVLogLevel(level int) {
 	C.test_set_av_log_level(C.int(level))
+}
+
+// ffmpegLogger holds the logger that videoStoreGoFFmpegLog routes lines to.
+// av_log_set_callback has no userdata pointer, so the shim has to reach the
+// logger via package state. atomic.Pointer keeps the read path lock-free for
+// the callback, which FFmpeg can fire from any decoder thread.
+var ffmpegLogger atomic.Pointer[logging.Logger]
+
+//export videoStoreGoFFmpegLog
+func videoStoreGoFFmpegLog(level C.int, msg *C.char) {
+	p := ffmpegLogger.Load()
+	if p == nil {
+		return
+	}
+	logger := *p
+	line := strings.TrimRight(C.GoString(msg), "\n")
+	switch {
+	case level <= C.AV_LOG_ERROR:
+		// AV_LOG_PANIC and AV_LOG_FATAL fall in here on purpose: zap's Fatal
+		// would os.Exit and we don't want a recoverable libav fatal to take
+		// down the module.
+		logger.Error(line)
+	case level <= C.AV_LOG_WARNING:
+		logger.Warn(line)
+	case level <= C.AV_LOG_INFO:
+		logger.Info(line)
+	default:
+		logger.Debug(line)
+	}
 }

--- a/videostore/utils/utils_ffmpeg_log_cgo.go
+++ b/videostore/utils/utils_ffmpeg_log_cgo.go
@@ -68,7 +68,8 @@ func setAVLogLevel(level int) {
 // ffmpegLogger holds the logger that videoStoreGoFFmpegLog routes lines to.
 // av_log_set_callback has no userdata pointer, so the shim has to reach the
 // logger via package state. atomic.Pointer keeps the read path lock-free for
-// the callback, which FFmpeg can fire from any decoder thread.
+// the callback, which FFmpeg can fire from any of its threads (demuxer,
+// segmenter, encoder, decoder, filter, etc.).
 var ffmpegLogger atomic.Pointer[logging.Logger]
 
 //export videoStoreGoFFmpegLog

--- a/videostore/utils/utils_ffmpeg_log_test.go
+++ b/videostore/utils/utils_ffmpeg_log_test.go
@@ -1,122 +1,54 @@
 package vsutils
 
 import (
-	"bytes"
-	"io"
-	"os"
 	"testing"
 
+	"go.viam.com/rdk/logging"
 	"go.viam.com/test"
-	"golang.org/x/sys/unix"
 )
 
-// captureFFmpegStreams redirects OS-level fd 1 (stdout) and fd 2 (stderr),
-// runs fn(), then returns what was written to each stream.
-// Go-level os.Pipe() is not sufficient because the C callback writes
-// directly via fprintf(stdout/stderr), requiring fd-level redirection.
-func captureFFmpegStreams(t *testing.T, fn func()) (stdout, stderr string) {
-	t.Helper()
-
-	origOut, err := unix.Dup(unix.Stdout)
-	test.That(t, err, test.ShouldBeNil)
-	origErr, err := unix.Dup(unix.Stderr)
-	test.That(t, err, test.ShouldBeNil)
-
-	rOut, wOut, err := os.Pipe()
-	test.That(t, err, test.ShouldBeNil)
-	rErr, wErr, err := os.Pipe()
-	test.That(t, err, test.ShouldBeNil)
-
-	err = unix.Dup2(int(wOut.Fd()), unix.Stdout)
-	test.That(t, err, test.ShouldBeNil)
-	err = unix.Dup2(int(wErr.Fd()), unix.Stderr)
-	test.That(t, err, test.ShouldBeNil)
-
-	fn()
-
-	// Restore original fds first. Dup2 onto fd 1/2 closes their current reference
-	// to the pipe write end; closing wOut/wErr drops the Go-side reference. Once
-	// all write ends are closed io.Copy below will see EOF.
-	err = unix.Dup2(origOut, unix.Stdout)
-	test.That(t, err, test.ShouldBeNil)
-	err = unix.Dup2(origErr, unix.Stderr)
-	test.That(t, err, test.ShouldBeNil)
-	unix.Close(origOut) //nolint:errcheck
-	unix.Close(origErr) //nolint:errcheck
-	wOut.Close()
-	wErr.Close()
-
-	// Read both streams concurrently to avoid blocking if one pipe buffer fills.
-	var outBuf, errBuf bytes.Buffer
-	done := make(chan struct{})
-	go func() {
-		io.Copy(&errBuf, rErr) //nolint:errcheck
-		rErr.Close()
-		close(done)
-	}()
-	io.Copy(&outBuf, rOut) //nolint:errcheck
-	rOut.Close()
-	<-done
-
-	return outBuf.String(), errBuf.String()
-}
-
 func TestFFmpegLogRouting(t *testing.T) {
-	SetFFmpegLogCallback()
-
 	origLevel := getAVLogLevel()
 	defer setAVLogLevel(origLevel)
 
-	t.Run("warnings and above route to stderr", func(t *testing.T) {
+	t.Run("levels map to logger levels", func(t *testing.T) {
 		cases := []struct {
-			level     int
-			wantLabel string
+			avLevel   int
+			wantLevel logging.Level
 		}{
-			{avLogFatal, "[FFmpeg Fatal]"},
-			{avLogError, "[FFmpeg Error]"},
-			{avLogWarning, "[FFmpeg Warn]"},
+			{avLogFatal, logging.ERROR},
+			{avLogError, logging.ERROR},
+			{avLogWarning, logging.WARN},
+			{avLogInfo, logging.INFO},
+			{avLogVerbose, logging.DEBUG},
+			{avLogDebug, logging.DEBUG},
 		}
-		setAVLogLevel(avLogDebug)
 		for _, tc := range cases {
-			t.Run(tc.wantLabel, func(t *testing.T) {
-				stdout, stderr := captureFFmpegStreams(t, func() {
-					emitAVLog(tc.level, "test routing message")
-				})
-				test.That(t, stderr, test.ShouldContainSubstring, tc.wantLabel)
-				test.That(t, stderr, test.ShouldContainSubstring, "test routing message")
-				test.That(t, stdout, test.ShouldBeEmpty)
-			})
-		}
-	})
+			t.Run(tc.wantLevel.String(), func(t *testing.T) {
+				logger, observed := logging.NewObservedTestLogger(t)
+				SetFFmpegLogCallback(logger)
+				setAVLogLevel(avLogDebug)
 
-	t.Run("info and below route to stdout", func(t *testing.T) {
-		cases := []struct {
-			level     int
-			wantLabel string
-		}{
-			{avLogInfo, "[FFmpeg Info]"},
-			{avLogVerbose, "[FFmpeg Verbose]"},
-			{avLogDebug, "[FFmpeg Debug]"},
-		}
-		setAVLogLevel(avLogDebug)
-		for _, tc := range cases {
-			t.Run(tc.wantLabel, func(t *testing.T) {
-				stdout, stderr := captureFFmpegStreams(t, func() {
-					emitAVLog(tc.level, "test routing message")
-				})
-				test.That(t, stdout, test.ShouldContainSubstring, tc.wantLabel)
-				test.That(t, stdout, test.ShouldContainSubstring, "test routing message")
-				test.That(t, stderr, test.ShouldBeEmpty)
+				emitAVLog(tc.avLevel, "test routing message")
+
+				entries := observed.TakeAll()
+				test.That(t, len(entries), test.ShouldEqual, 1)
+				// ObservedLogs entries carry a zapcore.Level (the observer is a
+				// zap construct, not an rdk abstraction), so convert via AsZap.
+				test.That(t, entries[0].Level, test.ShouldEqual, tc.wantLevel.AsZap())
+				test.That(t, entries[0].Message, test.ShouldContainSubstring, "test routing message")
+				test.That(t, entries[0].LoggerName, test.ShouldEndWith, "ffmpeg")
 			})
 		}
 	})
 
 	t.Run("messages below log level are suppressed", func(t *testing.T) {
+		logger, observed := logging.NewObservedTestLogger(t)
+		SetFFmpegLogCallback(logger)
 		setAVLogLevel(avLogWarning)
-		stdout, stderr := captureFFmpegStreams(t, func() {
-			emitAVLog(avLogInfo, "suppressed message")
-		})
-		test.That(t, stdout, test.ShouldBeEmpty)
-		test.That(t, stderr, test.ShouldBeEmpty)
+
+		emitAVLog(avLogInfo, "suppressed message")
+
+		test.That(t, len(observed.TakeAll()), test.ShouldEqual, 0)
 	})
 }

--- a/videostore/utils/utils_ffmpeg_log_test.go
+++ b/videostore/utils/utils_ffmpeg_log_test.go
@@ -33,8 +33,7 @@ func TestFFmpegLogRouting(t *testing.T) {
 
 				entries := observed.TakeAll()
 				test.That(t, len(entries), test.ShouldEqual, 1)
-				// ObservedLogs entries carry a zapcore.Level (the observer is a
-				// zap construct, not an rdk abstraction), so convert via AsZap.
+				// observer reports zapcore.Level, convert from logging.Level.
 				test.That(t, entries[0].Level, test.ShouldEqual, tc.wantLevel.AsZap())
 				test.That(t, entries[0].Message, test.ShouldContainSubstring, "test routing message")
 				test.That(t, entries[0].LoggerName, test.ShouldEndWith, "ffmpeg")


### PR DESCRIPTION
## Description

We currently have coarse FFmpeg log handling: the cgo callback formats each line and dumps it to stderr/stdout via fprintf, and we rely on the viam-server parent process to interpret stderr as errors and stdout as info.

This PR changes the callback to hand the formatted line and level up to a Go shim, which routes it through the module's logging.Logger under an ffmpeg sublogger (libav levels map onto rdk loglevels).

## Testing
- Unit tests verify mapping of FFmpeg loglevel to our rdk loglevels ✅ 
- Sanity check ffmpegLogger atomic.Pointer use by running tests with -race flag ✅ 
- test live on machine full stack with viamrtsp
  - confirm debug ✅ 
  - confirm info ✅ 
  - confirm error ✅ 
```
5/26/2026, 4:42:20 PM debug viamrtsp.ffmpeg     utils/utils_ffmpeg_log_cgo.go:94 [segment @ 0x7835c8000c00] -> pts:1445400 pts_time:16.06 dts:1445400 dts_time:16.06
5/26/2026, 4:42:20 PM debug viamrtsp.ffmpeg     utils/utils_ffmpeg_log_cgo.go:94 [segment @ 0x7835c8000c00] stream:0 start_pts_time:240.14 pts:23058000 pts_time:256.2 dts:23058000 dts_time:256.2
5/26/2026, 4:42:20 PM debug viamrtsp.ffmpeg     utils/utils_ffmpeg_log_cgo.go:94 [segment @ 0x7835c8000c00] -> pts:1449000 pts_time:16.1 dts:1449000 dts_time:16.1
5/26/2026, 4:42:20 PM debug viamrtsp.ffmpeg     utils/utils_ffmpeg_log_cgo.go:94 [segment @ 0x7835c8000c00] stream:0 start_pts_time:240.14 pts:23061600 pts_time:256.24 dts:23061600 dts_time:256.24
5/26/2026, 4:42:20 PM debug viamrtsp.ffmpeg     utils/utils_ffmpeg_log_cgo.go:94 [segment @ 0x7835c8000c00] -> pts:1454400 pts_time:16.16 dts:1454400 dts_time:16.16
``